### PR TITLE
Bug: RPC fails on /getinfo for blockchain height 1

### DIFF
--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -744,6 +744,10 @@ uint64_t Blockchain::getBlockTimestamp(uint32_t height) {
 uint64_t Blockchain::getMinimalFee(uint32_t height) {
 	std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
 
+	if (height == 0 || m_blocks.size() <= 1) {
+	    return 0;
+	}
+
 	if (height > m_blocks.size() - 1) {
 		height = m_blocks.size() - 1;
 	}


### PR DESCRIPTION
On running karbowanecd for the first time with testnet for the first time and blockchain is empty.
`/getinfo` request is failing.

Figured out that for empty blockchain getMinimaFee is broken.