### PR TITLE
Fix of fee check in Core (correct rule and formatting)

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -305,14 +305,14 @@ bool Core::check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_
   bool enough = true;
   if (!isFusionTransaction && !m_checkpoints.is_in_checkpoint_zone(getCurrentBlockchainHeight())) {
     if (getBlockMajorVersionForHeight(height) < BLOCK_MAJOR_VERSION_4) {
-      if (fee < m_currency.minimumFee()) {
-        logger(INFO) << "[Core] Transaction fee is not enough: " << m_currency.formatAmount(fee) << ", minimum fee: " << m_currency.minimumFee();
+      if (fee < CryptoNote::parameters::MINIMUM_FEE_V1) {
+        logger(INFO) << "[Core] Transaction fee is not enough: " << m_currency.formatAmount(fee) << ", minimum fee: " << m_currency.formatAmount(CryptoNote::parameters::MINIMUM_FEE_V1);
         enough = false;
       }
     } else {
       uint64_t min = getMinimalFeeForHeight(height);
       if (fee < (min - min * 20 / 100)) {
-        logger(INFO) << "[Core] Transaction fee is not enough: " << m_currency.formatAmount(fee) << ", minimum fee: " << min;
+        logger(INFO) << "[Core] Transaction fee is not enough: " << m_currency.formatAmount(fee) << ", minimum fee: " << m_currency.formatAmount(min);
         enough = false;
       }
     }


### PR DESCRIPTION
This fixes syncing from zero with flag `--without-checkpoints` which means full check including PoW and fee that was borked in some of the attempts to make fee as compatible as possible with old wallets. Old fee v1is set to v2 in dirty hack to make sure that the use of `currency.minimumFee()` will result in enough fee for tx to be valid, so we will use MINIMUM_FEE_V1 definition from config.