### PR TITLE
Ban nodes that stuck too deep behind on fork to spare useless traffic

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1299,6 +1299,10 @@ bool Core::is_tx_spendtime_unlocked(uint64_t unlock_time, uint32_t height) {
   return m_blockchain.is_tx_spendtime_unlocked(unlock_time, height);
 }
 
+bool Core::isInCheckpointZone(uint32_t height) const {
+  return m_checkpoints.is_in_checkpoint_zone(height);
+}
+
 bool Core::addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) {
   return m_blockchain.addMessageQueue(messageQueue);
 }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -137,6 +137,7 @@ namespace CryptoNote {
 
      void set_cryptonote_protocol(i_cryptonote_protocol* pprotocol);
      void set_checkpoints(Checkpoints&& chk_pts);
+     virtual bool isInCheckpointZone(uint32_t height) const override;
 
      std::vector<Transaction> getPoolTransactions() override;
      virtual size_t getPoolTransactionsCount() override;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -138,6 +138,7 @@ public:
   virtual void rollbackBlockchain(const uint32_t height) = 0;
   virtual bool saveBlockchain() = 0;
   virtual bool getMixin(const Transaction& transaction, uint64_t& mixin) = 0;
+  virtual bool isInCheckpointZone(uint32_t height) const = 0;
 };
 
 } //namespace CryptoNote


### PR DESCRIPTION
There are some unattended nodes with an outdated version of daemons that stuck on chain forks which spam our nodes over and over again with their chain to which our nodes won't reorg of course. This generates unneeded traffic because our nodes request from them their blocks attempting to sync.

Drop connection to those nodes if their height is below our standard reorg limit (which is the same as mined money unlock window) and if their height is in checkpoint zone (which ensures reorg is impossible anyway).