### PR TITLE
Lite blocks

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -147,7 +147,7 @@ const size_t   P2P_LOCAL_GRAY_PEERLIST_LIMIT                 =  5000;
 // and the minimum version for communication between nodes
 const uint8_t  P2P_VERSION_1                                 = 1;
 const uint8_t  P2P_VERSION_2                                 = 2;
-const uint8_t  P2P_CURRENT_VERSION                           = 1;
+const uint8_t  P2P_CURRENT_VERSION                           = 3;
 const uint8_t  P2P_MINIMUM_VERSION                           = 1;
 
 // This defines the number of versions ahead we must see peers before

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -154,6 +154,9 @@ const uint8_t  P2P_MINIMUM_VERSION                           = 1;
 // we start displaying warning messages that we need to upgrade our software
 const uint8_t  P2P_UPGRADE_WINDOW                            = 2;
 
+// This defines the minimum P2P version required for lite blocks propogation
+const uint8_t  P2P_LITE_BLOCKS_PROPOGATION_VERSION           = 3;
+
 const size_t   P2P_CONNECTION_MAX_WRITE_BUFFER_SIZE          = 64 * 1024 * 1024; // 64 MB
 const uint32_t P2P_DEFAULT_CONNECTIONS_COUNT                 = 8;
 const size_t   P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT     = 70;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -2,7 +2,8 @@
 // Copyright (c) 2014-2018, The Monero project
 // Copyright (c) 2014-2018, The Forknote developers
 // Copyright (c) 2018, Ryo Currency Project
-// Copyright (c) 2016-2018, The Karbowanec developers
+// Copyright (c) 2018-2019, The TurtleCoin developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -141,6 +142,17 @@ const int      RPC_DEFAULT_PORT                              =  32348;
 
 const size_t   P2P_LOCAL_WHITE_PEERLIST_LIMIT                =  1000;
 const size_t   P2P_LOCAL_GRAY_PEERLIST_LIMIT                 =  5000;
+
+// This defines our current P2P network version
+// and the minimum version for communication between nodes
+const uint8_t  P2P_VERSION_1                                 = 1;
+const uint8_t  P2P_VERSION_2                                 = 2;
+const uint8_t  P2P_CURRENT_VERSION                           = 1;
+const uint8_t  P2P_MINIMUM_VERSION                           = 1;
+
+// This defines the number of versions ahead we must see peers before
+// we start displaying warning messages that we need to upgrade our software
+const uint8_t  P2P_UPGRADE_WINDOW                            = 2;
 
 const size_t   P2P_CONNECTION_MAX_WRITE_BUFFER_SIZE          = 64 * 1024 * 1024; // 64 MB
 const uint32_t P2P_DEFAULT_CONNECTIONS_COUNT                 = 8;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -753,6 +753,14 @@ std::vector<Transaction> Core::getPoolTransactions() {
   return result;
 }
 
+bool getPoolTransaction(const Crypto::Hash& tx_hash, Transaction& transaction) {
+  if (!m_mempool.have_tx(tx_hash)) {
+    return false;
+  }
+
+  return m_mempool.getTransaction(tx_hash, transaction);
+}
+
 std::list<CryptoNote::tx_memory_pool::TransactionDetails> Core::getMemoryPool() const {
   //std::list<CryptoNote::tx_memory_pool::TransactionDetails> txs;
   //m_mempool.getMemoryPool(txs);

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -137,6 +137,22 @@ void Core::getTransactions(const std::vector<Crypto::Hash>& txs_ids, std::list<T
   m_blockchain.getTransactions(txs_ids, txs, missed_txs, checkTxPool);
 }
 
+bool Core::getTransaction(const Crypto::Hash& id, Transaction& tx, bool checkTxPool) {
+  std::vector<Crypto::Hash> txs_ids;
+  std::list<Transaction> txs;
+  std::list<Crypto::Hash> missed_txs;
+
+  txs_ids.push_back(id);
+  m_blockchain.getTransactions(txs_ids, txs, missed_txs, checkTxPool);
+
+  if (missed_txs.empty() && !txs.empty() && txs.size() == 1) {
+    tx = txs.front();
+    return true;
+  }
+
+  return false;
+}
+
 bool Core::get_alternative_blocks(std::list<Block>& blocks) {
   return m_blockchain.getAlternativeBlocks(blocks);
 }

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -753,7 +753,7 @@ std::vector<Transaction> Core::getPoolTransactions() {
   return result;
 }
 
-bool getPoolTransaction(const Crypto::Hash& tx_hash, Transaction& transaction) {
+bool Core::getPoolTransaction(const Crypto::Hash& tx_hash, Transaction& transaction) {
   if (!m_mempool.have_tx(tx_hash)) {
     return false;
   }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -128,6 +128,7 @@ namespace CryptoNote {
        uint32_t& resStartHeight, uint32_t& resCurrentHeight, uint32_t& resFullOffset, std::vector<BlockShortInfo>& entries) override;
      virtual Crypto::Hash getBlockIdByHeight(uint32_t height) override;
      void getTransactions(const std::vector<Crypto::Hash>& txs_ids, std::list<Transaction>& txs, std::list<Crypto::Hash>& missed_txs, bool checkTxPool = false) override;
+     virtual bool getTransaction(const Crypto::Hash& id, Transaction& tx, bool checkTxPool = false) override;
      virtual bool getBlockByHash(const Crypto::Hash &h, Block &blk) override;
      virtual bool getBlockHeight(const Crypto::Hash& blockId, uint32_t& blockHeight) override;
      //void get_all_known_block_ids(std::list<Crypto::Hash> &main, std::list<Crypto::Hash> &alt, std::list<Crypto::Hash> &invalid);

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -140,6 +140,7 @@ namespace CryptoNote {
      virtual bool isInCheckpointZone(uint32_t height) const override;
 
      std::vector<Transaction> getPoolTransactions() override;
+     bool getPoolTransaction(const Crypto::Hash& tx_hash, Transaction& transaction) override;
      virtual size_t getPoolTransactionsCount() override;
      virtual size_t getBlockchainTotalTransactions() override;
      //bool get_outs(uint64_t amount, std::list<Crypto::PublicKey>& pkeys);

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -97,6 +97,7 @@ public:
   virtual bool getBlockByHash(const Crypto::Hash &h, Block &blk) = 0;
   virtual bool getBlockHeight(const Crypto::Hash& blockId, uint32_t& blockHeight) = 0;
   virtual void getTransactions(const std::vector<Crypto::Hash>& txs_ids, std::list<Transaction>& txs, std::list<Crypto::Hash>& missed_txs, bool checkTxPool = false) = 0;
+  virtual bool getTransaction(const Crypto::Hash& id, Transaction& tx, bool checkTxPool = false) = 0;
   virtual bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) = 0;
   virtual bool getBlockSize(const Crypto::Hash& hash, size_t& size) = 0;
   virtual bool getAlreadyGeneratedCoins(const Crypto::Hash& hash, uint64_t& generatedCoins) = 0;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -81,6 +81,7 @@ public:
   virtual i_cryptonote_protocol* get_protocol() = 0;
   virtual bool handle_incoming_tx(const BinaryArray& tx_blob, tx_verification_context& tvc, bool keeped_by_block) = 0; //Deprecated. Should be removed with CryptoNoteProtocolHandler.
   virtual std::vector<Transaction> getPoolTransactions() = 0;
+  virtual bool getPoolTransaction(const Crypto::Hash& tx_hash, Transaction& transaction) = 0;
   virtual bool getPoolChanges(const Crypto::Hash& tailBlockId, const std::vector<Crypto::Hash>& knownTxsIds,
                               std::vector<Transaction>& addedTxs, std::vector<Crypto::Hash>& deletedTxsIds) = 0;
   virtual bool getPoolChangesLite(const Crypto::Hash& tailBlockId, const std::vector<Crypto::Hash>& knownTxsIds,

--- a/src/CryptoNoteCore/TransactionPool.cpp
+++ b/src/CryptoNoteCore/TransactionPool.cpp
@@ -248,6 +248,21 @@ namespace CryptoNote {
     removeTransaction(it);
     return true;
   }
+
+  //---------------------------------------------------------------------------------
+  bool tx_memory_pool::getTransaction(const Crypto::Hash& id, Transaction& tx) {
+    std::lock_guard<std::recursive_mutex> lock(m_transactions_lock);
+    auto it = m_transactions.find(id);
+    if (it == m_transactions.end()) {
+      return false;
+    }
+
+    auto& txd = *it;
+    tx = txd.tx;
+
+    return true;
+  }
+
   //---------------------------------------------------------------------------------
   size_t tx_memory_pool::get_transactions_count() const {
     std::lock_guard<std::recursive_mutex> lock(m_transactions_lock);

--- a/src/CryptoNoteCore/TransactionPool.h
+++ b/src/CryptoNoteCore/TransactionPool.h
@@ -123,6 +123,7 @@ namespace CryptoNote {
 
     bool getTransactionIdsByPaymentId(const Crypto::Hash& paymentId, std::vector<Crypto::Hash>& transactionIds);
     bool getTransactionIdsByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<Crypto::Hash>& hashes, uint64_t& transactionsNumberWithinTimestamps);
+    bool getTransaction(const Crypto::Hash& id, Transaction& tx);
 
     template<class t_ids_container, class t_tx_container, class t_missed_container>
     void getTransactions(const t_ids_container& txsIds, t_tx_container& txs, t_missed_container& missedTxs) {

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolDefinitions.h
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolDefinitions.h
@@ -1,4 +1,7 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -208,5 +211,42 @@ namespace CryptoNote
   struct NOTIFY_REQUEST_TX_POOL {
     const static int ID = BC_COMMANDS_POOL_BASE + 8;
     typedef NOTIFY_REQUEST_TX_POOL_request request;
+  };
+
+  /************************************************************************/
+  /*                                                                      */
+  /************************************************************************/
+  struct NOTIFY_NEW_LITE_BLOCK_request {
+    std::string block;
+    uint32_t current_blockchain_height;
+    uint32_t hop;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(block)
+      KV_MEMBER(current_blockchain_height)
+      KV_MEMBER(hop)
+    }
+  };
+
+  struct NOTIFY_NEW_LITE_BLOCK {
+    const static int ID = BC_COMMANDS_POOL_BASE + 9;
+    typedef NOTIFY_NEW_LITE_BLOCK_request request;
+  };
+
+  struct NOTIFY_MISSING_TXS_request {
+    Crypto::Hash blockHash;
+    uint32_t current_blockchain_height;
+    std::vector<Crypto::Hash> missing_txs;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(blockHash)
+      KV_MEMBER(current_blockchain_height)
+      serializeAsBinary(missing_txs, "missing_txs", s);
+    }
+  };
+
+  struct NOTIFY_MISSING_TXS {
+    const static int ID = BC_COMMANDS_POOL_BASE + 10;
+    typedef NOTIFY_MISSING_TXS_request request;
   };
 }

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Forknote project
-// Copyright (c) 2016-2019, The Karbowanec developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -725,7 +725,7 @@ void CryptoNoteProtocolHandler::relay_transactions(NOTIFY_NEW_TRANSACTIONS::requ
 }
 
 void CryptoNoteProtocolHandler::requestMissingPoolTransactions(const CryptoNoteConnectionContext& context) {
-  if (context.version < P2PProtocolVersion::V1) {
+  if (context.version < CryptoNote::P2P_VERSION_1) {
     return;
   }
 

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2018, The Forknote project
+// Copyright (c) 2014-2018, The Monero Project
+// Copyright (c) 2018-2019, The TurtleCoin Developers
 // Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
@@ -20,6 +22,7 @@
 #include "CryptoNoteProtocolHandler.h"
 
 #include <future>
+#include <boost/optional.hpp>
 #include <boost/scope_exit.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <System/Dispatcher.h>
@@ -241,7 +244,9 @@ int CryptoNoteProtocolHandler::handleCommand(bool is_notify, int command, const 
     HANDLE_NOTIFY(NOTIFY_RESPONSE_GET_OBJECTS, &CryptoNoteProtocolHandler::handle_response_get_objects)
     HANDLE_NOTIFY(NOTIFY_REQUEST_CHAIN, &CryptoNoteProtocolHandler::handle_request_chain)
     HANDLE_NOTIFY(NOTIFY_RESPONSE_CHAIN_ENTRY, &CryptoNoteProtocolHandler::handle_response_chain_entry)
-    HANDLE_NOTIFY(NOTIFY_REQUEST_TX_POOL, &CryptoNoteProtocolHandler::handleRequestTxPool)
+    HANDLE_NOTIFY(NOTIFY_REQUEST_TX_POOL, &CryptoNoteProtocolHandler::handle_request_tx_pool)
+    HANDLE_NOTIFY(NOTIFY_NEW_LITE_BLOCK, &CryptoNoteProtocolHandler::handle_notify_new_lite_block)
+    HANDLE_NOTIFY(NOTIFY_MISSING_TXS, &CryptoNoteProtocolHandler::handle_notify_missing_txs)
 
   default:
     handled = false;
@@ -288,7 +293,8 @@ int CryptoNoteProtocolHandler::handle_notify_new_block(int command, NOTIFY_NEW_B
   if (bvc.m_added_to_main_chain) {
     ++arg.hop;
     //TODO: Add here announce protocol usage
-    relay_post_notify<NOTIFY_NEW_BLOCK>(*m_p2p, arg, &context.m_connection_id);
+    //relay_post_notify<NOTIFY_NEW_BLOCK>(*m_p2p, arg, &context.m_connection_id);
+    relay_block(arg);
     // relay_block(arg, context);
 
     if (bvc.m_switched_to_alt_chain) {
@@ -311,26 +317,37 @@ int CryptoNoteProtocolHandler::handle_notify_new_transactions(int command, NOTIF
   if (context.m_state != CryptoNoteConnectionContext::state_normal)
     return 1;
 
-  for (auto tx_blob_it = arg.txs.begin(); tx_blob_it != arg.txs.end();) {
-    auto transactionBinary = asBinaryArray(*tx_blob_it);
-    Crypto::Hash transactionHash = Crypto::cn_fast_hash(transactionBinary.data(), transactionBinary.size());
-    logger(DEBUGGING) << "transaction " << transactionHash << " came in NOTIFY_NEW_TRANSACTIONS";
-
-    CryptoNote::tx_verification_context tvc = boost::value_initialized<decltype(tvc)>();
-    m_core.handle_incoming_tx(transactionBinary, tvc, false);
-    if (tvc.m_verification_failed) {
-      logger(Logging::DEBUGGING) << context << "Tx verification failed";
+  if (context.m_pending_lite_block) {
+    logger(Logging::TRACE) << context
+      << " Pending lite block detected, handling request as missing lite block transactions response";
+    std::vector<BinaryArray> _txs;
+    for (const auto tx : arg.txs) {
+      _txs.push_back(asBinaryArray(tx));
     }
-    if (!tvc.m_verification_failed && tvc.m_should_be_relayed) {
-      ++tx_blob_it;
-    } else {
-      tx_blob_it = arg.txs.erase(tx_blob_it);
-    }
-  }
+    return doPushLiteBlock(context.m_pending_lite_block->request, context, std::move(_txs));
+  } else {
+    for (auto tx_blob_it = arg.txs.begin(); tx_blob_it != arg.txs.end();) {
+      auto transactionBinary = asBinaryArray(*tx_blob_it);
+      Crypto::Hash transactionHash = Crypto::cn_fast_hash(transactionBinary.data(), transactionBinary.size());
+      logger(DEBUGGING) << "transaction " << transactionHash << " came in NOTIFY_NEW_TRANSACTIONS";
 
-  if (arg.txs.size()) {
-    //TODO: add announce usage here
-    relay_post_notify<NOTIFY_NEW_TRANSACTIONS>(*m_p2p, arg, &context.m_connection_id);
+      CryptoNote::tx_verification_context tvc = boost::value_initialized<decltype(tvc)>();
+      m_core.handle_incoming_tx(transactionBinary, tvc, false);
+      if (tvc.m_verification_failed) {
+        logger(Logging::DEBUGGING) << context << "Tx verification failed";
+      }
+      if (!tvc.m_verification_failed && tvc.m_should_be_relayed) {
+        ++tx_blob_it;
+      }
+      else {
+        tx_blob_it = arg.txs.erase(tx_blob_it);
+      }
+    }
+
+    if (arg.txs.size()) {
+      //TODO: add announce usage here
+      relay_post_notify<NOTIFY_NEW_TRANSACTIONS>(*m_p2p, arg, &context.m_connection_id);
+    }
   }
 
   return true;
@@ -559,6 +576,125 @@ bool CryptoNoteProtocolHandler::on_idle() {
   return m_core.on_idle();
 }
 
+int CryptoNoteProtocolHandler::doPushLiteBlock(NOTIFY_NEW_LITE_BLOCK::request arg, CryptoNoteConnectionContext &context,
+                                              std::vector<BinaryArray> missingTxs) {
+  Block b;
+  if (!fromBinaryArray(b, asBinaryArray(arg.block))) {
+    logger(Logging::WARNING) << context << "Deserialization of Block Template failed, dropping connection";
+    context.m_state = CryptoNoteConnectionContext::state_shutdown;
+    return 1;
+  }
+
+  std::unordered_map<Crypto::Hash, BinaryArray> provided_txs;
+  provided_txs.reserve(missingTxs.size());
+  for (const auto &missingTx : missingTxs) {
+    provided_txs[getBinaryArrayHash(missingTx)] = missingTx;
+  }
+
+  std::vector<BinaryArray> have_txs;
+  std::vector<Crypto::Hash> need_txs;
+
+  if (context.m_pending_lite_block) {
+    for (const auto &requestedTxHash : context.m_pending_lite_block->missed_transactions) {
+      if (provided_txs.find(requestedTxHash) == provided_txs.end()) {
+        logger(Logging::DEBUGGING) << context
+          << "Peer didn't provide a missing transaction, previously "
+          "acquired for a lite block, dropping connection.";
+        context.m_pending_lite_block.reset();
+        context.m_state = CryptoNoteConnectionContext::state_shutdown;
+        return 1;
+      }
+    }
+  }
+
+  /*
+   * here we are finding out which txs are present in the pool and which are not
+   * further we check for transactions in the blockchain to accept alternative blocks
+   */
+  for (const auto &transactionHash : b.transactionHashes) {
+    auto providedSearch = provided_txs.find(transactionHash);
+    if (providedSearch != provided_txs.end()) {
+      have_txs.push_back(providedSearch->second);
+    } else {
+      Transaction tx;
+      if (m_core.getTransaction(transactionHash, tx, true)) {
+        have_txs.push_back(toBinaryArray(tx));
+      } else {
+        need_txs.push_back(transactionHash);
+      }
+    }
+  }
+
+  /*
+   * if all txs are present then continue adding the block to
+   * blockchain storage and relaying the lite-block to other peers
+   *
+   * if not request the missing txs from the sender
+   * of the lite-block request
+   */
+  if (need_txs.empty()) {
+    context.m_pending_lite_block.reset();
+
+    for (auto transactionBinary : have_txs) {
+      CryptoNote::tx_verification_context tvc = boost::value_initialized<decltype(tvc)>();
+
+      m_core.handle_incoming_tx(transactionBinary, tvc, true);
+      if (tvc.m_verification_failed) {
+        logger(Logging::INFO) << context << "Lite block verification failed: transaction verification failed, dropping connection";
+        m_p2p->drop_connection(context, true);
+        return 1;
+      }
+    }
+
+    block_verification_context bvc = boost::value_initialized<block_verification_context>();
+    m_core.handle_incoming_block_blob(asBinaryArray(arg.block), bvc, true, false);
+    if (bvc.m_verification_failed) {
+      logger(Logging::DEBUGGING) << context << "Lite block verification failed, dropping connection";
+      m_p2p->drop_connection(context, true);
+      return 1;
+    }
+    if (bvc.m_added_to_main_chain) {
+      ++arg.hop;
+      //TODO: Add here announce protocol usage
+      relay_post_notify<NOTIFY_NEW_LITE_BLOCK>(*m_p2p, arg, &context.m_connection_id);
+
+      if (bvc.m_switched_to_alt_chain) {
+        requestMissingPoolTransactions(context);
+      }
+    }
+    else if (bvc.m_marked_as_orphaned) {
+      context.m_state = CryptoNoteConnectionContext::state_synchronizing;
+      NOTIFY_REQUEST_CHAIN::request r = boost::value_initialized<NOTIFY_REQUEST_CHAIN::request>();
+      r.block_ids = m_core.buildSparseChain();
+      logger(Logging::TRACE) << context << "-->>NOTIFY_REQUEST_CHAIN: m_block_ids.size()=" << r.block_ids.size();
+      post_notify<NOTIFY_REQUEST_CHAIN>(*m_p2p, r, context);
+    }
+  } else {
+    if (context.m_pending_lite_block.has_value()) {
+      context.m_pending_lite_block.reset();
+      logger(Logging::DEBUGGING) << context
+        << " Peer has a pending lite block but didn't provide all necessary "
+        "transactions, dropping the connection.";
+      context.m_state = CryptoNoteConnectionContext::state_shutdown;
+    } else {
+      NOTIFY_MISSING_TXS::request req;
+      req.current_blockchain_height = arg.current_blockchain_height;
+      req.blockHash = get_block_hash(b);
+      req.missing_txs = std::move(need_txs);
+      context.m_pending_lite_block = PendingLiteBlock{ arg, {req.missing_txs.begin(), req.missing_txs.end()} };
+
+      if (!post_notify<NOTIFY_MISSING_TXS>(*m_p2p, req, context)) {
+        logger(Logging::DEBUGGING) << context
+          << "Lite block is missing transactions but the publisher is not "
+          "reachable, dropping connection.";
+        context.m_state = CryptoNoteConnectionContext::state_shutdown;
+      }
+    }
+  }
+
+  return 1;
+}
+
 int CryptoNoteProtocolHandler::handle_request_chain(int command, NOTIFY_REQUEST_CHAIN::request& arg, CryptoNoteConnectionContext& context) {
   logger(Logging::TRACE) << context << "NOTIFY_REQUEST_CHAIN: m_block_ids.size()=" << arg.block_ids.size();
 
@@ -690,7 +826,7 @@ int CryptoNoteProtocolHandler::handle_response_chain_entry(int command, NOTIFY_R
   return 1;
 }
 
-int CryptoNoteProtocolHandler::handleRequestTxPool(int command, NOTIFY_REQUEST_TX_POOL::request& arg,
+int CryptoNoteProtocolHandler::handle_request_tx_pool(int command, NOTIFY_REQUEST_TX_POOL::request& arg,
                                                      CryptoNoteConnectionContext& context) {
   logger(Logging::TRACE) << context << "NOTIFY_REQUEST_TX_POOL: txs.size() = " << arg.txs.size();
 
@@ -713,10 +849,88 @@ int CryptoNoteProtocolHandler::handleRequestTxPool(int command, NOTIFY_REQUEST_T
   return 1;
 }
 
+int CryptoNoteProtocolHandler::handle_notify_new_lite_block(int command, NOTIFY_NEW_LITE_BLOCK::request &arg,
+                                                           CryptoNoteConnectionContext &context) {
+  logger(Logging::TRACE) << context << "NOTIFY_NEW_LITE_BLOCK (hop " << arg.hop << ")";
+  updateObservedHeight(arg.current_blockchain_height, context);
+  context.m_remote_blockchain_height = arg.current_blockchain_height;
+  if (context.m_state != CryptoNoteConnectionContext::state_normal) {
+    return 1;
+  }
+
+  return doPushLiteBlock(std::move(arg), context, {});
+}
+
+int CryptoNoteProtocolHandler::handle_notify_missing_txs(int command,  NOTIFY_MISSING_TXS::request &arg,
+                                                        CryptoNoteConnectionContext &context) {
+  logger(Logging::TRACE) << context << "NOTIFY_MISSING_TXS";
+
+  NOTIFY_NEW_TRANSACTIONS::request req;
+
+  std::list<Transaction> txs;
+  std::list<Crypto::Hash> missedHashes;
+  m_core.getTransactions(arg.missing_txs, txs, missedHashes, true);
+  if (!missedHashes.empty()) {
+    logger(Logging::DEBUGGING) << "Failed to Handle NOTIFY_MISSING_TXS, Unable to retrieve requested "
+      "transactions, Dropping Connection";
+    context.m_state = CryptoNoteConnectionContext::state_shutdown;
+    return 1;
+  } else {
+    for (auto& tx : txs) {
+      req.txs.push_back(asString(toBinaryArray(tx)));
+    }
+  }
+
+  logger(Logging::DEBUGGING) << "--> NOTIFY_RESPONSE_MISSING_TXS: "
+    << "txs.size() = " << req.txs.size();
+
+  if (post_notify<NOTIFY_NEW_TRANSACTIONS>(*m_p2p, req, context)) {
+    logger(Logging::DEBUGGING) << "NOTIFY_MISSING_TXS response sent to peer successfully";
+  } else {
+    logger(Logging::DEBUGGING) << "Error while sending NOTIFY_MISSING_TXS response to peer";
+  }
+
+  return 1;
+}
 
 void CryptoNoteProtocolHandler::relay_block(NOTIFY_NEW_BLOCK::request& arg) {
+  // generate a lite block request from the received normal block
+  NOTIFY_NEW_LITE_BLOCK::request lite_arg;
+  lite_arg.current_blockchain_height = arg.current_blockchain_height;
+  lite_arg.block = arg.b.block;
+  lite_arg.hop = arg.hop;
+
+  // encoding the request for sending the blocks to peers
   auto buf = LevinProtocol::encode(arg);
-  m_p2p->externalRelayNotifyToAll(NOTIFY_NEW_BLOCK::ID, buf, nullptr);
+  auto lite_buf = LevinProtocol::encode(lite_arg);
+
+  // logging the msg size to see the difference in payload size
+  logger(Logging::DEBUGGING) << "NOTIFY_NEW_BLOCK - MSG_SIZE = " << buf.size();
+  logger(Logging::DEBUGGING) << "NOTIFY_NEW_LITE_BLOCK - MSG_SIZE = " << lite_buf.size();
+
+  std::list<boost::uuids::uuid> liteBlockConnections, normalBlockConnections;
+
+  // sort the peers into their support categories
+  m_p2p->for_each_connection([this, &liteBlockConnections, &normalBlockConnections](
+    const CryptoNoteConnectionContext &ctx, uint64_t peerId) {
+    if (ctx.version >= P2P_LITE_BLOCKS_PROPOGATION_VERSION) {
+      logger(Logging::DEBUGGING) << ctx << "Peer supports lite-blocks... adding peer to lite block list";
+      liteBlockConnections.push_back(ctx.m_connection_id);
+    } else {
+      logger(Logging::DEBUGGING) << ctx << "Peer doesn't support lite-blocks... adding peer to normal block list";
+      normalBlockConnections.push_back(ctx.m_connection_id);
+    }
+  });
+
+  // first send lite blocks as it's faster
+  if (!liteBlockConnections.empty()) {
+    m_p2p->externalRelayNotifyToList(NOTIFY_NEW_LITE_BLOCK::ID, lite_buf, liteBlockConnections);
+  }
+
+  if (!normalBlockConnections.empty()) {
+    auto buf = LevinProtocol::encode(arg);
+    m_p2p->externalRelayNotifyToAll(NOTIFY_NEW_BLOCK::ID, buf, nullptr);
+  }
 }
 
 void CryptoNoteProtocolHandler::relay_transactions(NOTIFY_NEW_TRANSACTIONS::request& arg) {

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
@@ -95,7 +95,9 @@ namespace CryptoNote
     int handle_response_get_objects(int command, NOTIFY_RESPONSE_GET_OBJECTS::request& arg, CryptoNoteConnectionContext& context);
     int handle_request_chain(int command, NOTIFY_REQUEST_CHAIN::request& arg, CryptoNoteConnectionContext& context);
     int handle_response_chain_entry(int command, NOTIFY_RESPONSE_CHAIN_ENTRY::request& arg, CryptoNoteConnectionContext& context);
-    int handleRequestTxPool(int command, NOTIFY_REQUEST_TX_POOL::request& arg, CryptoNoteConnectionContext& context);
+    int handle_request_tx_pool(int command, NOTIFY_REQUEST_TX_POOL::request& arg, CryptoNoteConnectionContext& context);
+    int handle_notify_new_lite_block(int command, NOTIFY_NEW_LITE_BLOCK::request &arg, CryptoNoteConnectionContext &context);
+    int handle_notify_missing_txs(int command, NOTIFY_MISSING_TXS::request &arg, CryptoNoteConnectionContext &context);
 
     //----------------- i_cryptonote_protocol ----------------------------------
     virtual void relay_block(NOTIFY_NEW_BLOCK::request& arg) override;
@@ -111,6 +113,7 @@ namespace CryptoNote
     Logging::LoggerRef logger;
 
   private:
+    int doPushLiteBlock(NOTIFY_NEW_LITE_BLOCK::request block, CryptoNoteConnectionContext &context, std::vector<BinaryArray> missingTxs);
 
     System::Dispatcher& m_dispatcher;
     ICore& m_core;

--- a/src/P2p/ConnectionContext.h
+++ b/src/P2p/ConnectionContext.h
@@ -1,4 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -22,8 +24,11 @@
 #include <unordered_set>
 
 #include <boost/uuid/uuid.hpp>
+#include <boost/optional.hpp>
+
 #include "Common/StringTools.h"
 #include "crypto/hash.h"
+#include "p2p/PendingLiteBlock.h"
 
 namespace CryptoNote {
 
@@ -46,6 +51,7 @@ struct CryptoNoteConnectionContext {
   };
 
   state m_state = state_befor_handshake;
+  boost::optional<PendingLiteBlock> m_pending_lite_block;
   std::list<Crypto::Hash> m_needed_objects;
   std::unordered_set<Crypto::Hash> m_requested_objects;
   uint32_t m_remote_blockchain_height = 0;

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -354,6 +354,19 @@ namespace CryptoNote
     });
   }
 
+  //----------------------------------------------------------------------------------- 
+  void NodeServer::externalRelayNotifyToList(int command, const BinaryArray &data_buff, const std::list<boost::uuids::uuid> relayList) {
+    m_dispatcher.remoteSpawn([this, command, data_buff, relayList] {
+      forEachConnection([&](P2pConnectionContext &conn) {
+        if (std::find(relayList.begin(), relayList.end(), conn.m_connection_id) != relayList.end()) {
+          if (conn.peerId && (conn.m_state == CryptoNoteConnectionContext::state_normal || conn.m_state == CryptoNoteConnectionContext::state_synchronizing)) {
+            conn.pushMessage(P2pMessage(P2pMessage::NOTIFY, command, data_buff));
+          }
+        }
+      });
+    });
+  }
+
   //-----------------------------------------------------------------------------------
   bool NodeServer::make_default_config()
   {

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -2,7 +2,8 @@
 // Copyright (c) 2014-2018, The Monero project
 // Copyright (c) 2014-2018, The Forknote developers
 // Copyright (c) 2017-2019, The Iridium developers
-// Copyright (c) 2016-2019, The Karbowanec developers
+// Copyright (c) 2018-2019, The TurtleCoin developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -688,6 +689,16 @@ namespace CryptoNote
       return false;
     }
 
+    if (rsp.node_data.version < CryptoNote::P2P_MINIMUM_VERSION) {
+      logger(Logging::DEBUGGING) << context << "COMMAND_HANDSHAKE Failed, peer is wrong version! ("
+        << std::to_string(rsp.node_data.version) << "), closing connection.";
+      return false;
+    } else if ((rsp.node_data.version - CryptoNote::P2P_CURRENT_VERSION) >= CryptoNote::P2P_UPGRADE_WINDOW) {
+      logger(Logging::WARNING) << context
+        << "COMMAND_HANDSHAKE Warning, your software may be out of date. Please visit: "
+        << "https://github.com/seredat/karbowanec/releases for the latest version.";
+    }
+
     if (!handle_remote_peerlist(rsp.local_peerlist, rsp.node_data.local_time, context)) {
       add_host_fail(context.m_remote_ip);
       logger(Logging::DEBUGGING) << context << "COMMAND_HANDSHAKE: failed to handle_remote_peerlist(...), closing connection.";
@@ -1062,7 +1073,7 @@ namespace CryptoNote
   
   bool NodeServer::get_local_node_data(basic_node_data& node_data)
   {
-    node_data.version = P2PProtocolVersion::CURRENT;
+    node_data.version = CryptoNote::P2P_CURRENT_VERSION;
     time_t local_time;
     time(&local_time);
     node_data.local_time = local_time;

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 
 #include <boost/functional/hash.hpp>
+#include <boost/uuid/uuid.hpp>
 
 #include <System/Context.h>
 #include <System/ContextGroup.h>
@@ -187,6 +188,7 @@ namespace CryptoNote
     virtual void drop_connection(CryptoNoteConnectionContext& context, bool add_fail) override;
     virtual void for_each_connection(std::function<void(CryptoNote::CryptoNoteConnectionContext&, PeerIdType)> f) override;
     virtual void externalRelayNotifyToAll(int command, const BinaryArray& data_buff, const net_connection_id* excludeConnection) override;
+    virtual void externalRelayNotifyToList(int command, const BinaryArray &data_buff, const std::list<boost::uuids::uuid> relayList) override;
 
     //-----------------------------------------------------------------------------------------------
     bool add_host_fail(const uint32_t address_ip);

--- a/src/P2p/NetNodeCommon.h
+++ b/src/P2p/NetNodeCommon.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <list>
+#include <boost/uuid/uuid.hpp>
+
 #include "CryptoNote.h"
 #include "P2pProtocolTypes.h"
 #include "CryptoNoteConfig.h"
@@ -39,6 +42,7 @@ namespace CryptoNote {
     virtual void for_each_connection(std::function<void(CryptoNote::CryptoNoteConnectionContext&, PeerIdType)> f) = 0;
     // can be called from external threads
     virtual void externalRelayNotifyToAll(int command, const BinaryArray& data_buff, const net_connection_id* excludeConnection) = 0;
+    virtual void externalRelayNotifyToList(int command, const BinaryArray &data_buff, const std::list<boost::uuids::uuid> relayList) = 0;
   };
 
   struct p2p_endpoint_stub: public IP2pEndpoint {
@@ -51,5 +55,6 @@ namespace CryptoNote {
     virtual void for_each_connection(std::function<void(CryptoNote::CryptoNoteConnectionContext&, PeerIdType)> f) override {}
     virtual uint64_t get_connections_count() override { return 0; }   
     virtual void externalRelayNotifyToAll(int command, const BinaryArray& data_buff, const net_connection_id* excludeConnection) override {}
+    virtual void externalRelayNotifyToList(int command, const BinaryArray &data_buff, const std::list<boost::uuids::uuid> relayList) override {}
   };
 }

--- a/src/P2p/P2pProtocolDefinitions.h
+++ b/src/P2p/P2pProtocolDefinitions.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -50,12 +51,6 @@ namespace CryptoNote
     uint32_t packet_max_size;
     uint32_t config_id;
     uint32_t send_peerlist_sz;
-  };
-
-  enum P2PProtocolVersion : uint8_t {
-    V0 = 0,
-    V1 = 1,
-    CURRENT = V1
   };
 
   struct basic_node_data

--- a/src/P2p/PendingLiteBlock.h
+++ b/src/P2p/PendingLiteBlock.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2018-2019, The TurtleCoin Developers
+//
+// Please see the included LICENSE file for more information.
+
+#pragma once
+
+#include "CryptoNoteProtocol/CryptoNoteProtocolDefinitions.h"
+
+#include <unordered_set>
+
+namespace CryptoNote
+{
+    struct PendingLiteBlock
+    {
+        NOTIFY_NEW_LITE_BLOCK_request request;
+        std::unordered_set<Crypto::Hash> missed_transactions;
+    };
+} // namespace CryptoNote


### PR DESCRIPTION
Based on TurtleCoin implementation of Monero's fluffy blocks, this should reduce unneeded traffic by removing sending back and forth transactions along with blocks which nodes already have in most cases. Requires testing.