### PR TITLE
Change sending of unmixable outputs

### DIFF
--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2016, The Monero Project
-// Copyright (c) 2016-2019, Karbo developers
+// Copyright (c) 2016-2020, Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -91,7 +91,7 @@ public:
   virtual void synchronizationCompleted(std::error_code result) {}
   virtual void actualBalanceUpdated(uint64_t actualBalance) {}
   virtual void pendingBalanceUpdated(uint64_t pendingBalance) {}
-  virtual void unmixableBalanceUpdated(uint64_t dustBalance) {}
+  virtual void unmixableBalanceUpdated(uint64_t unmixableBalance) {}
   virtual void externalTransactionCreated(TransactionId transactionId) {}
   virtual void sendTransactionCompleted(TransactionId transactionId, std::error_code result) {}
   virtual void transactionUpdated(TransactionId transactionId) {}
@@ -120,7 +120,7 @@ public:
 
   virtual uint64_t actualBalance() = 0;
   virtual uint64_t pendingBalance() = 0;
-  virtual uint64_t dustBalance() = 0;
+  virtual uint64_t unmixableBalance() = 0;
 
   virtual size_t getTransactionCount() = 0;
   virtual size_t getTransferCount() = 0;
@@ -140,7 +140,6 @@ public:
 
   virtual TransactionId sendTransaction(const WalletLegacyTransfer& transfer, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
   virtual TransactionId sendTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
-  virtual TransactionId sendDustTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
   virtual TransactionId sendFusionTransaction(const std::list<TransactionOutputInformation>& fusionInputs, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
   virtual std::error_code cancelTransaction(size_t transferId) = 0;
 

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -694,7 +694,7 @@ namespace CryptoNote {
     if (height == upgradeHeight(CryptoNote::BLOCK_MAJOR_VERSION_5) + 1) {
       return 1000000; //return (cumulativeDifficulties[0] - cumulativeDifficulties[1]) / RESET_WORK_FACTOR;
     }
-    size_t count = difficultyBlocksCountByBlockVersion(blockMajorVersion);
+    uint32_t count = (uint32_t)difficultyBlocksCountByBlockVersion(blockMajorVersion);
     if (height > upgradeHeight(CryptoNote::BLOCK_MAJOR_VERSION_5) && height < CryptoNote::parameters::UPGRADE_HEIGHT_V5 + count) {
       uint32_t offset = count - (height - upgradeHeight(CryptoNote::BLOCK_MAJOR_VERSION_5));
       timestamps.erase(timestamps.begin(), timestamps.begin() + offset);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -573,6 +573,23 @@ bool processServerAliasResponse(const std::string& s, std::string& address) {
 	return true;
 }
 
+bool comfirmPrompt() {
+  std::string answer;
+  do {
+    std::cout << "y/n: ";
+    std::getline(std::cin, answer);
+
+    if (std::cin.fail() || std::cin.eof()) {
+      std::cin.clear();
+
+      break;
+    }
+
+  } while (answer != "y" && answer != "Y" && answer != "n" && answer != "N");
+
+  return answer == "y" || answer == "Y";
+}
+
 bool askAliasesTransfersConfirmation(const std::map<std::string, std::vector<WalletLegacyTransfer>>& aliases, const Currency& currency) {
 	std::cout << "Would you like to send money to the following addresses?" << std::endl;
 
@@ -582,20 +599,7 @@ bool askAliasesTransfersConfirmation(const std::map<std::string, std::vector<Wal
 		}
 	}
 
-	std::string answer;
-	do {
-		std::cout << "y/n: ";
-		std::getline(std::cin, answer);
-
-		if (std::cin.fail() || std::cin.eof()) {
-			std::cin.clear();
-
-			break;
-		}
-
-	} while (answer != "y" && answer != "Y" && answer != "n" && answer != "N");
-
-	return answer == "y" || answer == "Y";
+  return comfirmPrompt();
 }
 #endif
 
@@ -2086,9 +2090,8 @@ bool simple_wallet::transfer(const std::vector<std::string> &args) {
   }
 
   if (mixIn != 0 && unmixable_balance != 0) {
-    logger(WARNING, BRIGHT_YELLOW) << "You have unmixable coins " << m_currency.formatAmount(unmixable_balance) 
-                                   << ", sending them is only possible with zero <mixin_count>.";
-    return false;
+    logger(WARNING, BRIGHT_YELLOW) << "You have unmixable coins " << m_currency.formatAmount(unmixable_balance) << " in your wallet. "
+                                   << "If you encounter problems with sending, sweep them by making transaction with zero <mixin_count>.";
   }
 
   try {

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2016, XDN developers
 // Copyright (c) 2014-2017, The Monero Project
-// Copyright (c) 2016-2018, The Karbo developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // All rights reserved.
 // 
@@ -121,7 +121,6 @@ namespace CryptoNote
     bool set_log(const std::vector<std::string> &args);
     bool payment_id(const std::vector<std::string> &args);
     bool change_password(const std::vector<std::string> &args);
-    bool sweep_dust(const std::vector<std::string> &args);
     bool estimate_fusion(const std::vector<std::string> &args);
     bool optimize(const std::vector<std::string> &args);
     bool get_tx_key(const std::vector<std::string> &args);

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2016, The Monero Project
-// Copyright (c) 2016-2019, Karbo developers
+// Copyright (c) 2016-2020, Karbo developers
 //
 // All rights reserved.
 //
@@ -89,7 +89,7 @@ public:
 
   virtual uint64_t actualBalance() override;
   virtual uint64_t pendingBalance() override;
-  virtual uint64_t dustBalance() override;
+  virtual uint64_t unmixableBalance() override;
 
   virtual size_t getTransactionCount() override;
   virtual size_t getTransferCount() override;
@@ -109,7 +109,6 @@ public:
 
   virtual TransactionId sendTransaction(const WalletLegacyTransfer& transfer, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
   virtual TransactionId sendTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
-  virtual TransactionId sendDustTransaction(const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
   virtual TransactionId sendFusionTransaction(const std::list<TransactionOutputInformation>& fusionInputs, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) override;
   virtual std::error_code cancelTransaction(size_t transactionId) override;
 

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2018, Karbo developers
+// Copyright (c) 2016-2020, Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -127,32 +127,6 @@ std::shared_ptr<WalletRequest> WalletTransactionSender::makeSendRequest(Transact
   }
 
   return doSendTransaction(context, events);
-}
-
-std::shared_ptr<WalletRequest> WalletTransactionSender::makeSendDustRequest(TransactionId& transactionId, std::deque<std::shared_ptr<WalletLegacyEvent>>& events,
-	const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra, uint64_t mixIn, uint64_t unlockTimestamp) {
-
-	using namespace CryptoNote;
-
-	throwIf(transfers.empty(), error::ZERO_DESTINATION);
-	validateTransfersAddresses(transfers);
-	uint64_t neededMoney = countNeededMoney(fee, transfers);
-
-	std::shared_ptr<SendTransactionContext> context = std::make_shared<SendTransactionContext>();
-
-	context->foundMoney = selectDustTransfersToSend(neededMoney, m_currency.defaultDustThreshold(), context->selectedTransfers);
-	throwIf(context->foundMoney < neededMoney, error::WRONG_AMOUNT);
-
-	transactionId = m_transactionsCache.addNewTransaction(neededMoney, fee, extra, transfers, unlockTimestamp);
-	context->transactionId = transactionId;
-	context->mixIn = mixIn;
-
-	if (context->mixIn) {
-		std::shared_ptr<WalletRequest> request = makeGetRandomOutsRequest(context);
-		return request;
-	}
-
-	return doSendTransaction(context, events);
 }
 
 std::shared_ptr<WalletRequest> WalletTransactionSender::makeSendFusionRequest(TransactionId& transactionId, std::deque<std::shared_ptr<WalletLegacyEvent>>& events,
@@ -393,7 +367,7 @@ T popRandomValue(URNG& randomGenerator, std::vector<T>& vec) {
 }
 
 
-uint64_t WalletTransactionSender::selectTransfersToSend(uint64_t neededMoney, bool addDust, uint64_t dust, std::list<TransactionOutputInformation>& selectedTransfers) {
+uint64_t WalletTransactionSender::selectTransfersToSend(uint64_t neededMoney, bool addUnmixable, uint64_t dust, std::list<TransactionOutputInformation>& selectedTransfers) {
 
   std::vector<size_t> unusedTransfers;
   std::vector<size_t> unusedDust;
@@ -417,15 +391,13 @@ uint64_t WalletTransactionSender::selectTransfersToSend(uint64_t neededMoney, bo
     }
   }
 
-  bool selectOneUnmixable = addDust && !unusedUnmixable.empty();
   uint64_t foundMoney = 0;
 
-  while (foundMoney < neededMoney && (!unusedTransfers.empty() || !unusedDust.empty() || !unusedUnmixable.empty())) {
+  while (foundMoney < neededMoney && (!unusedTransfers.empty() || !unusedDust.empty() || (addUnmixable && !unusedUnmixable.empty()))) {
     size_t idx;
     std::mt19937 urng = Random::generator();
-    if (selectOneUnmixable) {
+    if (addUnmixable && !unusedUnmixable.empty()) {
       idx = popRandomValue(urng, unusedUnmixable);
-	  selectOneUnmixable = false;
     } else {
       idx = !unusedTransfers.empty() ? popRandomValue(urng, unusedTransfers) : popRandomValue(urng, unusedDust);
     }
@@ -436,69 +408,5 @@ uint64_t WalletTransactionSender::selectTransfersToSend(uint64_t neededMoney, bo
   return foundMoney;
 
 }
-
-uint64_t WalletTransactionSender::selectDustTransfersToSend(uint64_t neededMoney, uint64_t dust, std::list<TransactionOutputInformation>& selectedTransfers) {
-
-	std::vector<size_t> unusedTransfers;
-	std::vector<size_t> unusedDust;
-	std::vector<size_t> unusedUnmixable;
-	uint64_t neededUnmixable = 0;
-
-	std::vector<TransactionOutputInformation> outputs;
-	m_transferDetails.getOutputs(outputs, ITransfersContainer::IncludeKeyUnlocked);
-
-	for (size_t i = 0; i < outputs.size(); ++i) {
-		const auto& out = outputs[i];
-		if (!m_transactionsCache.isUsed(out)) {
-			if (is_valid_decomposed_amount(out.amount)) {
-				if (dust < out.amount) {
-					unusedTransfers.push_back(i);
-				}
-				else {
-					unusedDust.push_back(i);
-				}
-			}
-			else {
-				unusedUnmixable.push_back(i);
-				neededUnmixable += out.amount;
-			}
-		}
-	}
-
-	uint64_t foundMoney = 0;
-	// Sweep unmixable
-	if (!unusedUnmixable.empty()) {
-		while (foundMoney < neededUnmixable && !unusedUnmixable.empty()) {
-			size_t idx;
-			std::mt19937 urng = Random::generator();
-			idx = popRandomValue(urng, unusedUnmixable);
-			foundMoney += outputs[idx].amount;
-			selectedTransfers.push_back(outputs[idx]);
-		}
-	}
-	// Sweep dust
-	if (foundMoney < neededMoney) {
-		while (foundMoney < neededMoney && !unusedDust.empty()) {
-			size_t idx;
-			std::mt19937 urng = Random::generator();
-			idx = popRandomValue(urng, unusedDust);
-			selectedTransfers.push_back(outputs[idx]);
-			foundMoney += outputs[idx].amount;
-		}
-	}
-	// Optimize larger amounts if needed
-	if (foundMoney < neededMoney) {
-		while (foundMoney < neededMoney && !unusedTransfers.empty()) {
-			size_t idx;
-			std::mt19937 urng = Random::generator();
-			idx = popRandomValue(urng, unusedTransfers);
-			selectedTransfers.push_back(outputs[idx]);
-			foundMoney += outputs[idx].amount;
-		}
-	}
-	return foundMoney;
-
-}
-
 
 } /* namespace CryptoNote */

--- a/src/WalletLegacy/WalletTransactionSender.h
+++ b/src/WalletLegacy/WalletTransactionSender.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2018, Karbo developers
+// Copyright (c) 2016-2020, Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -41,9 +41,6 @@ public:
   std::shared_ptr<WalletRequest> makeSendRequest(TransactionId& transactionId, std::deque<std::shared_ptr<WalletLegacyEvent>>& events,
     const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0);
 
-  std::shared_ptr<WalletRequest> makeSendDustRequest(TransactionId& transactionId, std::deque<std::shared_ptr<WalletLegacyEvent>>& events,
-	  const std::vector<WalletLegacyTransfer>& transfers, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0);
-
   std::shared_ptr<WalletRequest> makeSendFusionRequest(TransactionId& transactionId, std::deque<std::shared_ptr<WalletLegacyEvent>>& events,
 	  const std::vector<WalletLegacyTransfer>& transfers, const std::list<TransactionOutputInformation>& fusionInputs, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0);
 
@@ -65,8 +62,7 @@ private:
   void validateTransfersAddresses(const std::vector<WalletLegacyTransfer>& transfers);
   bool validateDestinationAddress(const std::string& address);
 
-  uint64_t selectTransfersToSend(uint64_t neededMoney, bool addDust, uint64_t dust, std::list<TransactionOutputInformation>& selectedTransfers);
-  uint64_t selectDustTransfersToSend(uint64_t neededMoney, uint64_t dust, std::list<TransactionOutputInformation>& selectedTransfers);
+  uint64_t selectTransfersToSend(uint64_t neededMoney, bool addUnmixable, uint64_t dust, std::list<TransactionOutputInformation>& selectedTransfers);
 
   const Currency& m_currency;
   AccountKeys m_keys;


### PR DESCRIPTION
Change how we deal with unmixable balance:

- if transaction is zero mixin, first take all unmixable outputs to send, then normal outputs
- for transactions with mixin first, take normal outputs, only if not enough take dust, unmixable outputs, obviously, not used for sending
- `sweep_dust` command is removed from simplewallet
- the warning is displayed when the user has unmixable outputs that he can get rid of them by sending tx with zero mixin
- in the edge case of so many unmixable outputs that it will make tx invalid due to exceeding tx size limit user will have to send them in chunks (at cost of an extra fee, but old behaviour is the same)