### PR TITLE
Change spent key images storage

### DIFF
--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2228,7 +2228,7 @@ bool Blockchain::pushBlock(const Block& blockData, const std::vector<Transaction
     block.cumulative_difficulty += m_blocks.back().cumulative_difficulty;
   }
 
-  pushBlock(block);
+  pushBlock(block, blockHash);
 
   auto block_processing_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - blockProcessingStart).count();
 
@@ -2252,12 +2252,9 @@ bool Blockchain::pushBlock(const Block& blockData, const std::vector<Transaction
   return true;
 }
 
-bool Blockchain::pushBlock(BlockEntry& block) {
-  Crypto::Hash blockHash = get_block_hash(block.bl);
-
+bool Blockchain::pushBlock(BlockEntry& block, const Crypto::Hash& blockHash) {
   m_blocks.push_back(block);
   m_blockIndex.push(blockHash);
-
   m_timestampIndex.add(block.bl.timestamp, blockHash);
   m_generatedTransactionsIndex.add(block.bl);
 

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -19,17 +19,10 @@
 #pragma once
 
 #include <atomic>
+#include <unordered_map>
 
 #include "google/sparse_hash_set"
 #include "google/sparse_hash_map"
-
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/composite_key.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/mem_fun.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index/random_access_index.hpp>
 
 #include "Common/ObserverManager.h"
 #include "Common/Util.h"
@@ -208,16 +201,6 @@ namespace CryptoNote {
       }
     };
 
-    struct SpentKeyImage {
-      uint32_t blockIndex;
-      Crypto::KeyImage keyImage;
-
-      void serialize(ISerializer& s) {
-        s(blockIndex, "block_index");
-        s(keyImage, "key_image");
-      }
-    };
-
     void rollbackBlockchainTo(uint32_t height);
     bool have_tx_keyimg_as_spent(const Crypto::KeyImage &key_im);
 
@@ -271,22 +254,7 @@ namespace CryptoNote {
       }
     };
 
-    struct BlockIndexTag {};
-    struct KeyImageTag {};
-
-    typedef boost::multi_index_container<
-      SpentKeyImage,
-      boost::multi_index::indexed_by<
-        boost::multi_index::ordered_non_unique<
-          boost::multi_index::tag<BlockIndexTag>,
-          BOOST_MULTI_INDEX_MEMBER(SpentKeyImage, uint32_t, blockIndex)
-        >,
-        boost::multi_index::hashed_unique<
-          boost::multi_index::tag<KeyImageTag>,
-          BOOST_MULTI_INDEX_MEMBER(SpentKeyImage, Crypto::KeyImage, keyImage)
-        >
-      >
-    > SpentKeyImagesContainer;
+    typedef std::unordered_map<Crypto::KeyImage, uint32_t> SpentKeyImagesContainer;
     typedef std::unordered_map<Crypto::Hash, BlockEntry> blocks_ext_by_hash;
     typedef google::sparse_hash_map<uint64_t, std::vector<std::pair<TransactionIndex, uint16_t>>> outputs_container; //Crypto::Hash - tx hash, size_t - index of out in transaction
     typedef google::sparse_hash_map<uint64_t, std::vector<MultisignatureOutputUsage>> MultisignatureOutputsContainer;
@@ -297,7 +265,7 @@ namespace CryptoNote {
     Crypto::cn_context m_cn_context;
     Tools::ObserverManager<IBlockchainStorageObserver> m_observerManager;
 
-    SpentKeyImagesContainer spentKeyImages;
+    SpentKeyImagesContainer m_spent_key_images;
     size_t m_current_block_cumul_sz_limit;
     blocks_ext_by_hash m_alternative_chains; // Crypto::Hash -> block_extended_info
     outputs_container m_outputs;

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -357,7 +357,7 @@ namespace CryptoNote {
     const TransactionEntry& transactionByIndex(TransactionIndex index);
     bool pushBlock(const Block& blockData, const Crypto::Hash& id, block_verification_context& bvc);
     bool pushBlock(const Block& blockData, const std::vector<Transaction>& transactions, const Crypto::Hash& blockHash, block_verification_context& bvc);
-    bool pushBlock(BlockEntry& block);
+    bool pushBlock(BlockEntry& block, const Crypto::Hash& blockHash);
     void popBlock();
     bool pushTransaction(BlockEntry& block, const Crypto::Hash& transactionHash, TransactionIndex transactionIndex);
     void popTransaction(const Transaction& transaction, const Crypto::Hash& transactionHash);


### PR DESCRIPTION
to STL `unordered_map` instead of boost `multi_index_container` for spent key images, seems to result in smaller memory footprint and faster saving

![smaller memory footprint](https://user-images.githubusercontent.com/18482330/75444129-7f47b500-596b-11ea-9cbb-e1c54bd0f447.jpg)

