### PR TITLE
Deterministic transaction keys

### DIFF
--- a/include/CryptoNote.h
+++ b/include/CryptoNote.h
@@ -58,10 +58,12 @@ struct TransactionOutput {
   TransactionOutputTarget target;
 };
 
+using TransactionInputs = std::vector<TransactionInput>;
+
 struct TransactionPrefix {
   uint8_t version;
   uint64_t unlockTime;
-  std::vector<TransactionInput> inputs;
+  TransactionInputs inputs;
   std::vector<TransactionOutput> outputs;
   std::vector<uint8_t> extra;
 };

--- a/include/INode.h
+++ b/include/INode.h
@@ -170,6 +170,7 @@ public:
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) = 0;
   virtual void getBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback) = 0;
   virtual void getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) = 0;
+  virtual void getTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) = 0;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) = 0;
   virtual void getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<TransactionDetails>& transactions, const Callback& callback) = 0;
   virtual void getPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps, const Callback& callback) = 0;

--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -94,6 +94,8 @@ public:
 
   // serialized transaction
   virtual BinaryArray getTransactionData() const = 0;
+
+  virtual TransactionPrefix getTransactionPrefix() const = 0;
 };
 
 //

--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -60,6 +60,7 @@ public:
 
   virtual Crypto::Hash getTransactionHash() const = 0;
   virtual Crypto::Hash getTransactionPrefixHash() const = 0;
+  virtual Crypto::Hash getTransactionInputsHash() const = 0;
   virtual Crypto::PublicKey getTransactionPublicKey() const = 0;
   virtual bool getTransactionSecretKey(Crypto::SecretKey& key) const = 0;
   virtual uint64_t getUnlockTime() const = 0;

--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -75,6 +75,7 @@ public:
   virtual TransactionTypes::InputType getInputType(size_t index) const = 0;
   virtual void getInput(size_t index, KeyInput& input) const = 0;
   virtual void getInput(size_t index, MultisignatureInput& input) const = 0;
+  virtual std::vector<TransactionInput> getInputs() const = 0;
 
   // outputs
   virtual size_t getOutputCount() const = 0;

--- a/src/Common/BinaryArray.hpp
+++ b/src/Common/BinaryArray.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2012-2018, The CryptoNote developers, The Bytecoin developers.
+// Licensed under the GNU Lesser General Public License. See LICENSE for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <CryptoNote.h>
+
+using namespace CryptoNote;
+
+namespace Common {
+
+template<class It>
+inline BinaryArray::iterator append(BinaryArray &ba, It be, It en) {
+	return ba.insert(ba.end(), be, en);
+}
+inline BinaryArray::iterator append(BinaryArray &ba, size_t add, BinaryArray::value_type va) {
+	return ba.insert(ba.end(), add, va);
+}
+inline BinaryArray::iterator append(BinaryArray &ba, const BinaryArray &other) {
+	return ba.insert(ba.end(), other.begin(), other.end());
+}
+
+} // namespace Common

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -134,6 +134,18 @@ bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const Sec
   return generate_deterministic_tx_keys(ba, viewSecretKey, generatedKeys);
 }
 
+bool generateDeterministicTransactionKeys(const std::vector<TransactionInput> &inputs, const SecretKey& viewSecretKey, KeyPair& generatedKeys) {
+  BinaryArray ba;
+  for (const auto& in : inputs) {
+    uint64_t amount = 0;
+    if (in.type() == typeid(KeyInput)) {
+      Common::append(ba, std::begin(boost::get<KeyInput>(in).keyImage.data), std::end(boost::get<KeyInput>(in).keyImage.data));
+    }
+  }
+  
+  return generate_deterministic_tx_keys(ba, viewSecretKey, generatedKeys);
+}
+
 bool constructTransaction(
   const AccountKeys& sender_account_keys,
   const std::vector<TransactionSourceEntry>& sources,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -125,7 +125,6 @@ bool generate_deterministic_tx_keys(BinaryArray& keyImages, const Crypto::Secret
 bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const SecretKey& viewSecretKey, KeyPair& generatedKeys) {
   BinaryArray ba;
   for (const auto& in : tx.inputs) {
-    uint64_t amount = 0;
     if (in.type() == typeid(KeyInput)) {
       Common::append(ba, std::begin(boost::get<KeyInput>(in).keyImage.data), std::end(boost::get<KeyInput>(in).keyImage.data));
     }
@@ -137,12 +136,20 @@ bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const Sec
 bool generateDeterministicTransactionKeys(const std::vector<TransactionInput> &inputs, const SecretKey& viewSecretKey, KeyPair& generatedKeys) {
   BinaryArray ba;
   for (const auto& in : inputs) {
-    uint64_t amount = 0;
     if (in.type() == typeid(KeyInput)) {
       Common::append(ba, std::begin(boost::get<KeyInput>(in).keyImage.data), std::end(boost::get<KeyInput>(in).keyImage.data));
     }
   }
   
+  return generate_deterministic_tx_keys(ba, viewSecretKey, generatedKeys);
+}
+
+bool generateDeterministicTransactionKeys(const std::vector<KeyImage> &keyImages, const SecretKey& viewSecretKey, KeyPair& generatedKeys) {
+  BinaryArray ba;
+  for (const auto& im : keyImages) {
+     Common::append(ba, std::begin(im.data), std::end(im.data));
+  }
+
   return generate_deterministic_tx_keys(ba, viewSecretKey, generatedKeys);
 }
 

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -26,6 +26,7 @@
 
 #include "Serialization/BinaryOutputStreamSerializer.h"
 #include "Serialization/BinaryInputStreamSerializer.h"
+#include "CryptoNoteSerialization.h"
 
 #include "Account.h"
 #include "CryptoNoteBasicImpl.h"

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -126,6 +126,11 @@ bool generate_deterministic_tx_keys(const Crypto::Hash& inputsHash, const Crypto
   return Crypto::secret_key_to_public_key(generatedKeys.secretKey, generatedKeys.publicKey);
 }
 
+bool generateDeterministicTransactionKeys(const Transaction& tx, const SecretKey& viewSecretKey, KeyPair& generatedKeys) {
+  Crypto::Hash inputsHash = getObjectHash(tx.inputs);
+  return generate_deterministic_tx_keys(inputsHash, viewSecretKey, generatedKeys);
+}
+
 bool constructTransaction(
   const AccountKeys& sender_account_keys,
   const std::vector<TransactionSourceEntry>& sources,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -117,7 +117,7 @@ uint64_t get_tx_fee(const Transaction& tx) {
   return r;
 }
 
-bool generate_deterministic_tx_keys(const Crypto::Hash& inputsHash, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys) {
+bool generateDeterministicTransactionKeys(const Crypto::Hash& inputsHash, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys) {
   BinaryArray ba;
   Common::append(ba, std::begin(viewSecretKey.data), std::end(viewSecretKey.data));
   Common::append(ba, std::begin(inputsHash.data), std::end(inputsHash.data));
@@ -128,7 +128,7 @@ bool generate_deterministic_tx_keys(const Crypto::Hash& inputsHash, const Crypto
 
 bool generateDeterministicTransactionKeys(const Transaction& tx, const SecretKey& viewSecretKey, KeyPair& generatedKeys) {
   Crypto::Hash inputsHash = getObjectHash(tx.inputs);
-  return generate_deterministic_tx_keys(inputsHash, viewSecretKey, generatedKeys);
+  return generateDeterministicTransactionKeys(inputsHash, viewSecretKey, generatedKeys);
 }
 
 bool constructTransaction(
@@ -195,7 +195,7 @@ bool constructTransaction(
   }
 
   KeyPair txkey;
-  if (!generate_deterministic_tx_keys(getObjectHash(tx.inputs), sender_account_keys.viewSecretKey, txkey)) {
+  if (!generateDeterministicTransactionKeys(getObjectHash(tx.inputs), sender_account_keys.viewSecretKey, txkey)) {
     logger(ERROR) << "Couldn't generate deterministic transaction keys";
     return false;
   }

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -55,6 +55,7 @@ struct TransactionDestinationEntry {
 
 bool generate_deterministic_tx_keys(BinaryArray& keyImages, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
+bool generateDeterministicTransactionKeys(const std::vector<TransactionInput>& inputs, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 
 bool constructTransaction(
   const AccountKeys& senderAccountKeys,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -53,7 +53,7 @@ struct TransactionDestinationEntry {
   TransactionDestinationEntry(uint64_t amount, const AccountPublicAddress &addr) : amount(amount), addr(addr) {}
 };
 
-bool generate_deterministic_tx_keys(const Crypto::Hash& inputsHash, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
+bool generateDeterministicTransactionKeys(const Crypto::Hash& inputsHash, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 bool generateDeterministicTransactionKeys(const Transaction& tx, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 
 bool constructTransaction(

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -54,6 +54,7 @@ struct TransactionDestinationEntry {
 };
 
 bool generate_deterministic_tx_keys(const Crypto::Hash& inputsHash, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
+bool generateDeterministicTransactionKeys(const Transaction& tx, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 
 bool constructTransaction(
   const AccountKeys& senderAccountKeys,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -20,6 +20,7 @@
 
 #include <boost/utility/value_init.hpp>
 
+#include <CryptoNote.h>
 #include "CryptoNoteBasic.h"
 #include "CryptoNoteSerialization.h"
 
@@ -52,6 +53,8 @@ struct TransactionDestinationEntry {
   TransactionDestinationEntry(uint64_t amount, const AccountPublicAddress &addr) : amount(amount), addr(addr) {}
 };
 
+bool generate_deterministic_tx_keys(BinaryArray& keyImages, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
+bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 
 bool constructTransaction(
   const AccountKeys& senderAccountKeys,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -56,6 +56,7 @@ struct TransactionDestinationEntry {
 bool generate_deterministic_tx_keys(BinaryArray& keyImages, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 bool generateDeterministicTransactionKeys(const std::vector<TransactionInput>& inputs, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
+bool generateDeterministicTransactionKeys(const std::vector<Crypto::KeyImage>& keyImages, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 
 bool constructTransaction(
   const AccountKeys& senderAccountKeys,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -53,10 +53,7 @@ struct TransactionDestinationEntry {
   TransactionDestinationEntry(uint64_t amount, const AccountPublicAddress &addr) : amount(amount), addr(addr) {}
 };
 
-bool generate_deterministic_tx_keys(BinaryArray& keyImages, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
-bool generateDeterministicTransactionKeys(const TransactionPrefix &tx, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
-bool generateDeterministicTransactionKeys(const std::vector<TransactionInput>& inputs, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
-bool generateDeterministicTransactionKeys(const std::vector<Crypto::KeyImage>& keyImages, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
+bool generate_deterministic_tx_keys(const Crypto::Hash& inputsHash, const Crypto::SecretKey& viewSecretKey, KeyPair& generatedKeys);
 
 bool constructTransaction(
   const AccountKeys& senderAccountKeys,

--- a/src/CryptoNoteCore/CryptoNoteSerialization.cpp
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.cpp
@@ -276,6 +276,10 @@ void serialize(MultisignatureInput& multisignature, ISerializer& serializer) {
   serializer(multisignature.outputIndex, "outputIndex");
 }
 
+void serialize(TransactionInputs & inputs, ISerializer & serializer) {
+  serializer(inputs, "vin");
+}
+
 void serialize(TransactionOutput& output, ISerializer& serializer) {
   serializer(output.amount, "amount");
   serializer(output.target, "target");

--- a/src/CryptoNoteCore/CryptoNoteSerialization.h
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.h
@@ -49,6 +49,8 @@ void serialize(BaseInput& gen, ISerializer& serializer);
 void serialize(KeyInput& key, ISerializer& serializer);
 void serialize(MultisignatureInput& multisignature, ISerializer& serializer);
 
+void serialize(TransactionInputs & inputs, ISerializer & serializer);
+
 void serialize(TransactionOutput& output, ISerializer& serializer);
 void serialize(TransactionOutputTarget& output, ISerializer& serializer);
 void serialize(KeyOutput& key, ISerializer& serializer);

--- a/src/CryptoNoteCore/Transaction.cpp
+++ b/src/CryptoNoteCore/Transaction.cpp
@@ -70,6 +70,7 @@ namespace CryptoNote {
     virtual TransactionTypes::InputType getInputType(size_t index) const override;
     virtual void getInput(size_t index, KeyInput& input) const override;
     virtual void getInput(size_t index, MultisignatureInput& input) const override;
+    virtual std::vector<TransactionInput> getInputs() const override;
 
     // outputs
     virtual size_t getOutputCount() const override;
@@ -473,6 +474,10 @@ namespace CryptoNote {
 
   void TransactionImpl::getInput(size_t index, MultisignatureInput& input) const {
     input = boost::get<MultisignatureInput>(getInputChecked(transaction, index, TransactionTypes::InputType::Multisignature));
+  }
+
+  std::vector<TransactionInput> TransactionImpl::getInputs() const {
+    return transaction.inputs;
   }
 
   size_t TransactionImpl::getOutputCount() const {

--- a/src/CryptoNoteCore/Transaction.cpp
+++ b/src/CryptoNoteCore/Transaction.cpp
@@ -58,6 +58,7 @@ namespace CryptoNote {
     // ITransactionReader
     virtual Hash getTransactionHash() const override;
     virtual Hash getTransactionPrefixHash() const override;
+    virtual Hash getTransactionInputsHash() const override;
     virtual PublicKey getTransactionPublicKey() const override;
     virtual uint64_t getUnlockTime() const override;
     virtual bool getPaymentId(Hash& hash) const override;
@@ -202,6 +203,10 @@ namespace CryptoNote {
 
   Hash TransactionImpl::getTransactionPrefixHash() const {
     return getObjectHash(*static_cast<const TransactionPrefix*>(&transaction));
+  }
+
+  Hash TransactionImpl::getTransactionInputsHash() const {
+    return getObjectHash(transaction.inputs);
   }
 
   PublicKey TransactionImpl::getTransactionPublicKey() const {

--- a/src/CryptoNoteCore/Transaction.cpp
+++ b/src/CryptoNoteCore/Transaction.cpp
@@ -54,7 +54,7 @@ namespace CryptoNote {
     TransactionImpl();
     TransactionImpl(const BinaryArray& txblob);
     TransactionImpl(const CryptoNote::Transaction& tx);
-  
+
     // ITransactionReader
     virtual Hash getTransactionHash() const override;
     virtual Hash getTransactionPrefixHash() const override;
@@ -88,6 +88,8 @@ namespace CryptoNote {
 
     // get serialized transaction
     virtual BinaryArray getTransactionData() const override;
+
+    TransactionPrefix getTransactionPrefix() const override;
 
     // ITransactionWriter
 
@@ -157,7 +159,7 @@ namespace CryptoNote {
     return std::unique_ptr<ITransaction>(new TransactionImpl(tx));
   }
 
-  TransactionImpl::TransactionImpl() {   
+  TransactionImpl::TransactionImpl() {
     CryptoNote::KeyPair txKeys(CryptoNote::generateKeyPair());
 
     TransactionExtraPublicKey pk = { txKeys.publicKey };
@@ -174,7 +176,7 @@ namespace CryptoNote {
     if (!fromBinaryArray(transaction, ba)) {
       throw std::runtime_error("Invalid transaction data");
     }
-    
+
     extra.parse(transaction.extra);
     transactionHash = getBinaryArrayHash(ba); // avoid serialization if we already have blob
   }
@@ -194,7 +196,7 @@ namespace CryptoNote {
       transactionHash = getObjectHash(transaction);
     }
 
-    return transactionHash.get();   
+    return transactionHash.get();
   }
 
   Hash TransactionImpl::getTransactionPrefixHash() const {
@@ -295,7 +297,7 @@ namespace CryptoNote {
     MultisignatureOutput outMsig;
     outMsig.requiredSignatureCount = requiredSignatures;
     outMsig.keys.resize(to.size());
-    
+
     for (size_t i = 0; i < to.size(); ++i) {
       derivePublicKey(to[i], txKey, outputIndex, outMsig.keys[i]);
     }
@@ -400,6 +402,10 @@ namespace CryptoNote {
 
   BinaryArray TransactionImpl::getTransactionData() const {
     return toBinaryArray(transaction);
+  }
+
+  TransactionPrefix TransactionImpl::getTransactionPrefix() const {
+    return transaction;
   }
 
   void TransactionImpl::setPaymentId(const Hash& hash) {

--- a/src/CryptoNoteCore/TransactionPrefixImpl.cpp
+++ b/src/CryptoNoteCore/TransactionPrefixImpl.cpp
@@ -52,6 +52,7 @@ public:
   virtual TransactionTypes::InputType getInputType(size_t index) const override;
   virtual void getInput(size_t index, KeyInput& input) const override;
   virtual void getInput(size_t index, MultisignatureInput& input) const override;
+  virtual std::vector<TransactionInput> getInputs() const override;
 
   // outputs
   virtual size_t getOutputCount() const override;
@@ -158,6 +159,10 @@ void TransactionPrefixImpl::getInput(size_t index, KeyInput& input) const {
 
 void TransactionPrefixImpl::getInput(size_t index, MultisignatureInput& input) const {
   input = boost::get<MultisignatureInput>(getInputChecked(m_txPrefix, index, TransactionTypes::InputType::Multisignature));
+}
+
+std::vector<TransactionInput> TransactionPrefixImpl::getInputs() const {
+  return m_txPrefix.inputs;
 }
 
 size_t TransactionPrefixImpl::getOutputCount() const {

--- a/src/CryptoNoteCore/TransactionPrefixImpl.cpp
+++ b/src/CryptoNoteCore/TransactionPrefixImpl.cpp
@@ -38,6 +38,7 @@ public:
 
   virtual Hash getTransactionHash() const override;
   virtual Hash getTransactionPrefixHash() const override;
+  virtual Hash getTransactionInputsHash() const override;
   virtual PublicKey getTransactionPublicKey() const override;
   virtual uint64_t getUnlockTime() const override;
 
@@ -99,6 +100,10 @@ Hash TransactionPrefixImpl::getTransactionHash() const {
 
 Hash TransactionPrefixImpl::getTransactionPrefixHash() const {
   return getObjectHash(m_txPrefix);
+}
+
+Hash TransactionPrefixImpl::getTransactionInputsHash() const {
+  return getObjectHash(m_txPrefix.inputs);
 }
 
 PublicKey TransactionPrefixImpl::getTransactionPublicKey() const {

--- a/src/CryptoNoteCore/TransactionPrefixImpl.cpp
+++ b/src/CryptoNoteCore/TransactionPrefixImpl.cpp
@@ -72,6 +72,8 @@ public:
   // serialized transaction
   virtual BinaryArray getTransactionData() const override;
 
+  virtual TransactionPrefix getTransactionPrefix() const override;
+
   virtual bool getTransactionSecretKey(SecretKey& key) const override;
 
 private:
@@ -209,6 +211,10 @@ bool TransactionPrefixImpl::validateSignatures() const {
 
 BinaryArray TransactionPrefixImpl::getTransactionData() const {
   return toBinaryArray(m_txPrefix);
+}
+
+TransactionPrefix TransactionPrefixImpl::getTransactionPrefix() const {
+   return m_txPrefix;
 }
 
 bool TransactionPrefixImpl::getTransactionSecretKey(SecretKey& key) const {

--- a/src/InProcessNode/InProcessNode.cpp
+++ b/src/InProcessNode/InProcessNode.cpp
@@ -1002,6 +1002,69 @@ std::error_code InProcessNode::doGetBlocks(uint64_t timestampBegin, uint64_t tim
   return std::error_code();
 }
 
+void InProcessNode::getTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) {
+  std::unique_lock<std::mutex> lock(mutex);
+  if (state != INITIALIZED) {
+    lock.unlock();
+    callback(make_error_code(CryptoNote::error::NOT_INITIALIZED));
+    return;
+  }
+
+  ioService.post(
+    std::bind(
+      static_cast<
+      void(InProcessNode::*)(
+        const Crypto::Hash&,
+        CryptoNote::Transaction&,
+        const Callback&
+        )
+      >(&InProcessNode::getTransactionAsync),
+      this,
+      std::cref(transactionHash),
+      std::ref(transaction),
+      callback
+    )
+  );
+}
+
+void InProcessNode::getTransactionAsync(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) {
+  std::error_code ec = core.executeLocked(
+    std::bind(
+      static_cast<
+      std::error_code(InProcessNode::*)(
+        const Crypto::Hash&,
+        CryptoNote::Transaction&
+        )
+      >(&InProcessNode::doGetTransaction),
+      this,
+      std::cref(transactionHash),
+      std::ref(transaction)
+    )
+  );
+  callback(ec);
+}
+
+std::error_code InProcessNode::doGetTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction) {
+  try {
+    std::list<Transaction> txs;
+    std::list<Crypto::Hash> missed_txs;
+    std::vector<Crypto::Hash> transactionHashes;
+    transactionHashes.push_back(transactionHash);
+    core.getTransactions(transactionHashes, txs, missed_txs, true);
+    if (missed_txs.size() > 0) {
+      return make_error_code(CryptoNote::error::REQUEST_ERROR);
+    }
+    transaction = std::move(txs.front());
+  }
+  catch (std::system_error& e) {
+    return e.code();
+  }
+  catch (std::exception&) {
+    return make_error_code(CryptoNote::error::INTERNAL_NODE_ERROR);
+  }
+  return std::error_code();
+}
+
 void InProcessNode::getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) {
   std::unique_lock<std::mutex> lock(mutex);
   if (state != INITIALIZED) {

--- a/src/InProcessNode/InProcessNode.h
+++ b/src/InProcessNode/InProcessNode.h
@@ -92,6 +92,7 @@ public:
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) override;
   virtual void getBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback) override;
   virtual void getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) override;
+  virtual void getTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) override;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void getPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps, const Callback& callback) override;
@@ -139,6 +140,9 @@ private:
 
   void getBlocksAsync(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback);
   std::error_code doGetBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps);
+
+  void getTransactionAsync(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback);
+  std::error_code doGetTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction);
 
   void getTransactionsAsync(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback);
   std::error_code doGetTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions);

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -37,6 +37,7 @@
 #include "Common/FormatTools.h"
 #include "Common/StringTools.h"
 #include "CryptoNoteCore/CryptoNoteBasicImpl.h"
+#include "CryptoNoteCore/CryptoNoteFormatUtils.h"
 #include "CryptoNoteCore/CryptoNoteTools.h"
 #include "Rpc/CoreRpcServerCommandsDefinitions.h"
 #include "Rpc/HttpClient.h"
@@ -641,6 +642,17 @@ std::error_code NodeRpcProxy::doGetConnections(std::vector<p2pConnection>& conne
   return ec;
 }
 
+void NodeRpcProxy::getTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_state != STATE_INITIALIZED) {
+    callback(make_error_code(error::NOT_INITIALIZED));
+    return;
+  }
+
+  scheduleRequest(std::bind(&NodeRpcProxy::doGetTransaction, this, std::cref(transactionHash), std::ref(transaction)), callback);
+}
+
+
 void NodeRpcProxy::getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_state != STATE_INITIALIZED) {
@@ -865,6 +877,35 @@ std::error_code NodeRpcProxy::doGetTransactionHashesByPaymentId(const Crypto::Ha
   }
 
   transactionHashes = std::move(resp.transactionHashes);
+  return ec;
+}
+
+std::error_code NodeRpcProxy::doGetTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction) {
+  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_TRANSACTIONS::response  resp = AUTO_VAL_INIT(resp);
+
+  req.txs_hashes.push_back(Common::podToHex(transactionHash));
+
+  std::error_code ec = jsonCommand("/gettransactions", req, resp);
+  if (ec) {
+    return ec;
+  }
+
+  if (resp.missed_txs.size() > 0) {
+    return make_error_code(CryptoNote::error::REQUEST_ERROR);
+  }
+
+  BinaryArray tx_blob;
+  if (!Common::fromHex(resp.txs_as_hex[0], tx_blob)) {
+    return make_error_code(error::INTERNAL_NODE_ERROR);
+  }
+
+  Crypto::Hash tx_hash = NULL_HASH;
+  Crypto::Hash tx_prefixt_hash = NULL_HASH;
+  if (!parseAndValidateTransactionFromBinaryArray(tx_blob, transaction, tx_hash, tx_prefixt_hash) || tx_hash != transactionHash) {
+    return make_error_code(error::INTERNAL_NODE_ERROR);
+  }
+
   return ec;
 }
 

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -95,6 +95,7 @@ public:
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) override;
   virtual void getBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback) override;
   virtual void getBlock(const uint32_t blockHeight, BlockDetails &block, const Callback& callback) override;
+  virtual void getTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) override;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void getPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps, const Callback& callback) override;
@@ -137,6 +138,7 @@ private:
   std::error_code doGetBlocksByHash(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks);
   std::error_code doGetBlock(const uint32_t blockHeight, BlockDetails& block);
   std::error_code doGetTransactionHashesByPaymentId(const Crypto::Hash& paymentId, std::vector<Crypto::Hash>& transactionHashes);
+  std::error_code doGetTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction);
   std::error_code doGetTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions);
   std::error_code doGetBlockTimestamp(uint32_t height, uint64_t& timestamp);
   std::error_code doGetConnections(std::vector<p2pConnection>& connections);

--- a/src/PaymentGate/NodeFactory.cpp
+++ b/src/PaymentGate/NodeFactory.cpp
@@ -94,6 +94,8 @@ public:
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<CryptoNote::TransactionDetails>& transactions,
     const Callback& callback) override { }
 
+  virtual void getTransaction(const Crypto::Hash& transactionHash, CryptoNote::Transaction& transaction, const Callback& callback) override {}
+
   virtual void getPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<CryptoNote::TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps,
     const Callback& callback) override { }
 

--- a/src/Transfers/TransfersConsumer.cpp
+++ b/src/Transfers/TransfersConsumer.cpp
@@ -69,7 +69,7 @@ void findMyOutputs(
   auto txPublicKey = tx.getTransactionPublicKey();
   KeyDerivation derivation;
 
-  if (!generate_key_derivation( txPublicKey, viewSecretKey, derivation)) {
+  if (!generate_key_derivation(txPublicKey, viewSecretKey, derivation)) {
     return;
   }
 
@@ -462,7 +462,7 @@ std::error_code TransfersConsumer::createTransfers(
         if (it == transactions_hash_seen.end()) {
           std::unordered_set<Crypto::PublicKey>::iterator key_it = public_keys_seen.find(key);
           if (key_it != public_keys_seen.end()) {
-			  m_logger(ERROR, BRIGHT_RED) << "Failed to process transaction " << Common::podToHex(txHash) << ": duplicate multisignature output key is found";
+            m_logger(ERROR, BRIGHT_RED) << "Failed to process transaction " << Common::podToHex(txHash) << ": duplicate multisignature output key is found";
             return std::error_code();
           }
           if (std::find(temp_keys.begin(), temp_keys.end(), key) != temp_keys.end()) {

--- a/src/Transfers/TransfersConsumer.cpp
+++ b/src/Transfers/TransfersConsumer.cpp
@@ -401,7 +401,7 @@ std::error_code TransfersConsumer::createTransfers(
 
   if (account.spendSecretKey == NULL_SECRET_KEY) {
     KeyPair deterministic_tx_keys;
-    bool spending = generateDeterministicTransactionKeys(tx.getTransactionPrefix(), account.viewSecretKey, deterministic_tx_keys)
+    bool spending = generateDeterministicTransactionKeys(tx.getTransactionInputsHash(), account.viewSecretKey, deterministic_tx_keys)
       && deterministic_tx_keys.publicKey == txPubKey;
 
     if (spending) {

--- a/src/Transfers/TransfersConsumer.cpp
+++ b/src/Transfers/TransfersConsumer.cpp
@@ -399,12 +399,14 @@ std::error_code TransfersConsumer::createTransfers(
   std::vector<PublicKey> temp_keys;
   std::lock_guard<std::mutex> lk(seen_mutex);
 
-  KeyPair deterministic_tx_keys;
-  bool spending = generateDeterministicTransactionKeys(tx.getTransactionPrefix(), account.viewSecretKey, deterministic_tx_keys)
-    && deterministic_tx_keys.publicKey == txPubKey;
+  if (account.spendSecretKey == NULL_SECRET_KEY) {
+    KeyPair deterministic_tx_keys;
+    bool spending = generateDeterministicTransactionKeys(tx.getTransactionPrefix(), account.viewSecretKey, deterministic_tx_keys)
+      && deterministic_tx_keys.publicKey == txPubKey;
 
-  if (spending) {
-    m_logger(WARNING, BRIGHT_YELLOW) << "Spending in tx " << Common::podToHex(tx.getTransactionHash());
+    if (spending) {
+      m_logger(WARNING, BRIGHT_YELLOW) << "Spending in tx " << Common::podToHex(tx.getTransactionHash());
+    }
   }
 
   for (auto idx : outputs) {

--- a/src/Transfers/TransfersConsumer.cpp
+++ b/src/Transfers/TransfersConsumer.cpp
@@ -399,6 +399,14 @@ std::error_code TransfersConsumer::createTransfers(
   std::vector<PublicKey> temp_keys;
   std::lock_guard<std::mutex> lk(seen_mutex);
 
+  KeyPair deterministic_tx_keys;
+  bool spending = generateDeterministicTransactionKeys(tx.getTransactionPrefix(), account.viewSecretKey, deterministic_tx_keys)
+    && deterministic_tx_keys.publicKey == txPubKey;
+
+  if (spending) {
+    m_logger(WARNING, BRIGHT_YELLOW) << "Spending in tx " << Common::podToHex(tx.getTransactionHash());
+  }
+
   for (auto idx : outputs) {
 
     if (idx >= tx.getOutputCount()) {

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -51,6 +51,7 @@
 #include "CryptoNoteCore/CryptoNoteSerialization.h"
 #include "CryptoNoteCore/CryptoNoteTools.h"
 #include "CryptoNoteCore/TransactionApi.h"
+#include "CryptoNoteCore/TransactionExtra.h"
 #include "crypto/crypto.h"
 #include "crypto/random.h"
 #include "Transfers/TransfersContainer.h"
@@ -2737,6 +2738,36 @@ std::vector<TransactionOutputInformation> WalletGreen::getTransfers(size_t index
   return allTransfers;
 }
 
+Crypto::SecretKey WalletGreen::getTransactionDeterministicSecretKey(Crypto::Hash& transactionHash) const {
+  throwIfNotInitialized();
+  throwIfStopped();
+
+  Crypto::SecretKey txKey = CryptoNote::NULL_SECRET_KEY;
+
+  auto getTransactionCompleted = std::promise<std::error_code>();
+  auto getTransactionWaitFuture = getTransactionCompleted.get_future();
+  CryptoNote::Transaction tx;
+  m_node.getTransaction(std::move(transactionHash), std::ref(tx),
+    [&getTransactionCompleted](std::error_code ec) {
+    auto detachedPromise = std::move(getTransactionCompleted);
+    detachedPromise.set_value(ec);
+  });
+  std::error_code ec = getTransactionWaitFuture.get();
+  if (ec) {
+    m_logger(ERROR) << "Failed to get tx: " << ec << ", " << ec.message();
+    return CryptoNote::NULL_SECRET_KEY;
+  }
+
+  Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
+  KeyPair deterministicTxKeys;
+  bool ok = generateDeterministicTransactionKeys(tx, m_viewSecretKey, deterministicTxKeys)
+    && deterministicTxKeys.publicKey == txPubKey;
+
+  return ok ? deterministicTxKeys.secretKey : CryptoNote::NULL_SECRET_KEY;
+
+  return txKey;
+}
+
 Crypto::SecretKey WalletGreen::getTransactionSecretKey(size_t transactionIndex) const {
   throwIfNotInitialized();
   throwIfStopped();
@@ -2746,7 +2777,13 @@ Crypto::SecretKey WalletGreen::getTransactionSecretKey(size_t transactionIndex) 
     throw std::system_error(make_error_code(CryptoNote::error::INDEX_OUT_OF_RANGE));
   }
 
-  return m_transactions.get<RandomAccessIndex>()[transactionIndex].secretKey.get();
+  Crypto::SecretKey txKey = m_transactions.get<RandomAccessIndex>()[transactionIndex].secretKey.get_value_or(CryptoNote::NULL_SECRET_KEY);
+  if (txKey == CryptoNote::NULL_SECRET_KEY) {
+    Crypto::Hash transactionHash = m_transactions.get<RandomAccessIndex>()[transactionIndex].hash;
+    txKey = getTransactionDeterministicSecretKey(transactionHash);
+  }
+
+  return txKey;
 }
 
 Crypto::SecretKey WalletGreen::getTransactionSecretKey(Crypto::Hash& transactionHash) const {
@@ -2754,7 +2791,13 @@ Crypto::SecretKey WalletGreen::getTransactionSecretKey(Crypto::Hash& transaction
   throwIfStopped();
 
   auto txInfo = getTransaction(transactionHash);
-  return txInfo.transaction.secretKey.get_value_or(CryptoNote::NULL_SECRET_KEY);
+  Crypto::SecretKey txKey = txInfo.transaction.secretKey.get_value_or(CryptoNote::NULL_SECRET_KEY);
+
+  if (txKey == CryptoNote::NULL_SECRET_KEY) {
+    txKey = getTransactionDeterministicSecretKey(transactionHash);
+  }
+
+  return txKey;
 }
 
 bool WalletGreen::getTransactionProof(const Crypto::Hash& transactionHash, const CryptoNote::AccountPublicAddress& destinationAddress, const Crypto::SecretKey& txKey, std::string& transactionProof) {

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -155,6 +155,7 @@ protected:
   std::vector<std::string> doCreateAddressList(const std::vector<NewAddressData>& addressDataList);
 
   CryptoNote::BlockDetails getBlock(const uint32_t blockHeight);
+  Crypto::SecretKey getTransactionDeterministicSecretKey(Crypto::Hash& transactionHash) const;
 
   uint64_t scanHeightToTimestamp(const uint32_t scanHeight);
   uint64_t getCurrentTimestampAdjusted();

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -1000,7 +1000,7 @@ Crypto::SecretKey WalletLegacy::getTxKey(Crypto::Hash& txid) {
 
     Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
     KeyPair deterministicTxKeys;
-    bool ok = generateDeterministicTransactionKeys(tx.inputs, m_account.getAccountKeys().viewSecretKey, deterministicTxKeys)
+    bool ok = generateDeterministicTransactionKeys(tx, m_account.getAccountKeys().viewSecretKey, deterministicTxKeys)
       && deterministicTxKeys.publicKey == txPubKey;
 
     return ok ? deterministicTxKeys.secretKey : reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -972,16 +972,41 @@ std::vector<TransactionId> WalletLegacy::deleteOutdatedUnconfirmedTransactions()
   return m_transactionsCache.deleteOutdatedTransactions();
 }
 
+/* Returns either deterministic key or stored in wallet cache
+ * (returns null key if is absent in cache).
+ * In order to generate deterministic key raw transaction is 
+ * requested from Node.
+ */
 Crypto::SecretKey WalletLegacy::getTxKey(Crypto::Hash& txid) {
   TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
   WalletLegacyTransaction transaction;
   getTransaction(ti, transaction);
-  if (transaction.secretKey) {
-     return reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
+  if (transaction.secretKey && NULL_SECRET_KEY != reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get())) {
+    return reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
   } else {
-     return NULL_SECRET_KEY;
+    auto getTransactionCompleted = std::promise<std::error_code>();
+    auto getTransactionWaitFuture = getTransactionCompleted.get_future();
+    CryptoNote::Transaction tx;
+    m_node.getTransaction(std::move(txid), std::ref(tx),
+      [&getTransactionCompleted](std::error_code ec) {
+      auto detachedPromise = std::move(getTransactionCompleted);
+      detachedPromise.set_value(ec);
+    });
+    std::error_code ec = getTransactionWaitFuture.get();
+    if (ec) {
+      m_logger(ERROR) << "Failed to get tx: " << ec << ", " << ec.message();
+      return reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
+    }
+
+    Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
+    KeyPair deterministicTxKeys;
+    bool ok = generateDeterministicTransactionKeys(tx.inputs, m_account.getAccountKeys().viewSecretKey, deterministicTxKeys)
+      && deterministicTxKeys.publicKey == txPubKey;
+
+    return ok ? deterministicTxKeys.secretKey : reinterpret_cast<const Crypto::SecretKey&>(transaction.secretKey.get());
   }
 }
+
 bool WalletLegacy::get_tx_key(Crypto::Hash& txid, Crypto::SecretKey& txSecretKey) {
   TransactionId ti = m_transactionsCache.findTransactionByHash(txid);
   WalletLegacyTransaction transaction;


### PR DESCRIPTION
The `secret transaction key` allows, for example, proving that transaction was sent to a specified address and how much money this address received in a given transaction when used directly (undesired) or when used to generate a "proof of payment" (preferable). Since it is randomly generated, it needs to be stored in a wallet cache and/or recorded somewhere by the sender. In the case of wallet reset these keys are lost along with other transaction data, such as destination addresses. Likewise, upon restoring and importing the wallet from keys or mnemonic seed this transaction key is not recovered.

Replacing the randomly generated secret transaction key with deterministic using transaction `inputs` and sender's `secret view key` gives the next benefits:
* recovering the secret transaction key in case of wallet reset and/or restoring from mnemonic or keys
* recovering the secret transaction key even in tracking wallet thanks to using `secret view key` instead of `secret spend key`
* can be used to alert about spending in tracking wallet (possible further improvement of tracking wallets to enable tracking of outgoing transactions and displaying correct balance)