### PR TITLE
Proper Base58 encoding of proofs

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -34,6 +34,7 @@ const uint64_t CRYPTONOTE_MAX_BLOCK_NUMBER                   = 500000000;
 const size_t   CRYPTONOTE_MAX_BLOCK_BLOB_SIZE                = 500000000;
 const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
 const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 111; // addresses start with "K"
+const uint64_t CRYPTONOTE_TX_PROOF_BASE58_PREFIX             = 3576968; // (0x369488), starts with "Proof..."
 const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 10;
 const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW_V1       = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;
 const size_t   CRYPTONOTE_TX_SPENDABLE_AGE                   = 6;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -35,6 +35,7 @@ const size_t   CRYPTONOTE_MAX_BLOCK_BLOB_SIZE                = 500000000;
 const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
 const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 111; // addresses start with "K"
 const uint64_t CRYPTONOTE_TX_PROOF_BASE58_PREFIX             = 3576968; // (0x369488), starts with "Proof..."
+const uint64_t CRYPTONOTE_RESERVE_PROOF_BASE58_PREFIX        = 44907175188; // (0xa74ad1d14), starts with "RsrvPrf..."
 const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 10;
 const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW_V1       = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;
 const size_t   CRYPTONOTE_TX_SPENDABLE_AGE                   = 6;

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -622,9 +622,7 @@ bool getTransactionProof(const Crypto::Hash& transactionHash, const CryptoNote::
     return false;
   }
 
-  transactionProof = std::string("ProofV1") +
-    Tools::Base58::encode(std::string((const char *)&rA, sizeof(Crypto::PublicKey))) +
-    Tools::Base58::encode(std::string((const char *)&sig, sizeof(Crypto::Signature)));
+  transactionProof = Tools::Base58::encode_addr(CryptoNote::parameters::CRYPTONOTE_TX_PROOF_BASE58_PREFIX, std::string((const char *)&rA, sizeof(Crypto::PublicKey)) + std::string((const char *)&sig, sizeof(Crypto::Signature)));
 
   return true;
 }

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -713,9 +713,9 @@ bool getReserveProof(const std::vector<TransactionOutputInformation>& selectedTr
   memcpy(&p.signature, &signature, sizeof(signature));
 
   BinaryArray ba = toBinaryArray(p);
-  std::string ret = Common::toHex(ba);
+  std::string ret(ba.begin(), ba.end());
 
-  reserveProof = "ReserveProofV1" + Tools::Base58::encode(ret);
+  reserveProof = Tools::Base58::encode_addr(CryptoNote::parameters::CRYPTONOTE_RESERVE_PROOF_BASE58_PREFIX, ret);
 
   return true;
 }


### PR DESCRIPTION
Change the way the "transaction / payment proof" and "reserve / balance proof" are encoded. 

Instead of adding `ProofV1` to the beginning of the string of the Base58 encoded proof, use proper  Base58 encoding with varint prefix tag which allows checking decoded data with checksum, just as CryptoNote address is encoded. The same applies to the "reserve proof": instead of adding `ReserveProofV1` piece to Base58 encoded string of the reserve proof use proper encoding.

For this purpose two prefix tags are introduced:
`const uint64_t CRYPTONOTE_TX_PROOF_BASE58_PREFIX             = 3576968; // (0x369488), starts with "Proof..."`
`const uint64_t CRYPTONOTE_RESERVE_PROOF_BASE58_PREFIX        = 44907175188; // (0xa74ad1d14), starts with "RsrvPrf..."`

Of course, this will require the update of the wallets so the generated proofs can be verified on new nodes.
