### PR TITLE
Transaction fees per byte for extra data

### DIFF
--- a/include/BlockchainExplorerData.h
+++ b/include/BlockchainExplorerData.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -90,33 +91,34 @@ struct TransactionExtraDetails {
 };
 
 struct transactionOutputDetails2 {
-	TransactionOutput output;
-	uint64_t globalIndex;
+  TransactionOutput output;
+  uint64_t globalIndex;
 };
 
 struct BaseInputDetails {
-	BaseInput input;
-	uint64_t amount;
+  BaseInput input;
+  uint64_t amount;
 };
 
 struct KeyInputDetails {
-	KeyInput input;
-	uint64_t mixin;
-	std::vector<TransactionOutputReferenceDetails> outputs;
+  KeyInput input;
+  uint64_t mixin;
+  std::vector<TransactionOutputReferenceDetails> outputs;
 };
 
 struct MultisignatureInputDetails {
-	MultisignatureInput input;
-	TransactionOutputReferenceDetails output;
+  MultisignatureInput input;
+  TransactionOutputReferenceDetails output;
 };
 
 typedef boost::variant<BaseInputDetails, KeyInputDetails, MultisignatureInputDetails> transactionInputDetails2;
 
 struct TransactionExtraDetails2 {
-	std::vector<size_t> padding;
-	Crypto::PublicKey publicKey;
-	BinaryArray nonce;
-	BinaryArray raw;
+  std::vector<size_t> padding;
+  Crypto::PublicKey publicKey;
+  BinaryArray nonce;
+  BinaryArray raw;
+  size_t size = 0;
 };
 
 struct TransactionDetails {

--- a/src/BlockchainExplorer/BlockchainExplorerDataBuilder.cpp
+++ b/src/BlockchainExplorer/BlockchainExplorerDataBuilder.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -70,6 +71,7 @@ bool BlockchainExplorerDataBuilder::fillTxExtra(const std::vector<uint8_t>& rawE
       extraDetails.nonce = boost::get<TransactionExtraNonce>(field).nonce;
     }
   }
+  extraDetails.size = rawExtra.size();
   return true;
 }
 

--- a/src/BlockchainExplorer/BlockchainExplorerDataBuilder.h
+++ b/src/BlockchainExplorer/BlockchainExplorerDataBuilder.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2016-2019, The Karbo developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -69,7 +69,7 @@ const uint64_t MAXIMUM_FEE                                   = UINT64_C(10000000
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(100000000);
 const uint64_t MIN_TX_MIXIN_SIZE                             = 2;
 const uint64_t MAX_TX_MIXIN_SIZE                             = 20;
-const uint32_t MIN_TX_MIXIN_HEIGHT                           = 216394;
+const uint32_t MIN_TX_MIXIN_HEIGHT                           = MINIMUM_FEE_V2_HEIGHT;
 const uint32_t FEE_PER_BYTE_HEIGHT                           = 500000;
 const uint64_t MAX_EXTRA_SIZE                                = 1024;
 

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -61,15 +61,12 @@ const size_t   CRYPTONOTE_DISPLAY_DECIMAL_POINT              = 12;
 
 const uint64_t MINIMUM_FEE_V1                                = UINT64_C(100000000);
 const uint64_t MINIMUM_FEE_V2                                = UINT64_C(100000000000);
-const uint32_t MINIMUM_FEE_V2_HEIGHT                         = 216394;
 const uint64_t MINIMUM_FEE                                   = MINIMUM_FEE_V2;
 const uint64_t MAXIMUM_FEE                                   = UINT64_C(100000000000);
 
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(100000000);
 const uint64_t MIN_TX_MIXIN_SIZE                             = 2;
 const uint64_t MAX_TX_MIXIN_SIZE                             = 20;
-const uint32_t MIN_TX_MIXIN_HEIGHT                           = MINIMUM_FEE_V2_HEIGHT;
-const uint32_t FEE_PER_BYTE_HEIGHT                           = 500000;
 const uint64_t MAX_EXTRA_SIZE                                = 1024;
 
 const uint64_t MAX_TRANSACTION_SIZE_LIMIT                    = CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_CURRENT / 4 - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
@@ -106,11 +103,14 @@ const size_t   FUSION_TX_MAX_SIZE                            = CRYPTONOTE_BLOCK_
 const size_t   FUSION_TX_MIN_INPUT_COUNT                     = 12;
 const size_t   FUSION_TX_MIN_IN_OUT_COUNT_RATIO              = 4;
 
-const uint32_t UPGRADE_HEIGHT_V2                             = 60000;
-const uint32_t UPGRADE_HEIGHT_V3                             = 216000;
-const uint32_t UPGRADE_HEIGHT_V4                             = 266000;
-const uint32_t UPGRADE_HEIGHT_LWMA3                          = 300000;
-const uint32_t UPGRADE_HEIGHT_V5                             = 4294967294;
+const uint32_t UPGRADE_HEIGHT_V2                             = 60000;  // Block v2, pre-LWMA
+const uint32_t UPGRADE_HEIGHT_V3                             = 216000; // Block v3, LWMA1
+const uint32_t UPGRADE_HEIGHT_V3_1                           = 216394; // Min fee v2, cap max mixin
+const uint32_t UPGRADE_HEIGHT_V4                             = 266000; // Block v4, LWMA2, adaptive min fee, min mixin, disable slave merge mining
+const uint32_t UPGRADE_HEIGHT_V4_1                           = 300000; // LWMA3
+const uint32_t UPGRADE_HEIGHT_V4_2                           = 500000; // Fee per-byte for extra, ban unmixable denominations
+const uint32_t UPGRADE_HEIGHT_V5                             = 4294967294; // Block v5, back to LWMA1+
+
 const unsigned UPGRADE_VOTING_THRESHOLD                      = 90; // percent
 const uint32_t UPGRADE_VOTING_WINDOW                         = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks
 const uint32_t UPGRADE_WINDOW                                = EXPECTED_NUMBER_OF_BLOCKS_PER_DAY;  // blocks

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -68,12 +68,9 @@ const uint64_t MAXIMUM_FEE                                   = UINT64_C(10000000
 
 const uint64_t DEFAULT_DUST_THRESHOLD                        = UINT64_C(100000000);
 const uint64_t MIN_TX_MIXIN_SIZE                             = 2;
-const uint64_t MAX_TX_MIXIN_SIZE_V1                          = 50;
-const uint64_t MAX_TX_MIXIN_SIZE_V2                          = 20;
-const uint64_t MAX_TX_MIXIN_SIZE                             = MAX_TX_MIXIN_SIZE_V2;
-const uint32_t MIN_TX_MIXIN_V1_HEIGHT                        = 216245;
-const uint32_t MIN_TX_MIXIN_V2_HEIGHT                        = 216394;
-const uint32_t FEE_PER_BYTE_HEIGHT                           = 490000;
+const uint64_t MAX_TX_MIXIN_SIZE                             = 20;
+const uint32_t MIN_TX_MIXIN_HEIGHT                           = 216394;
+const uint32_t FEE_PER_BYTE_HEIGHT                           = 500000;
 const uint64_t MAX_EXTRA_SIZE                                = 1024;
 
 const uint64_t MAX_TRANSACTION_SIZE_LIMIT                    = CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_CURRENT / 4 - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -74,6 +74,7 @@ const uint64_t MAX_TX_MIXIN_SIZE                             = MAX_TX_MIXIN_SIZE
 const uint32_t MIN_TX_MIXIN_V1_HEIGHT                        = 216245;
 const uint32_t MIN_TX_MIXIN_V2_HEIGHT                        = 216394;
 const uint32_t FEE_PER_BYTE_HEIGHT                           = 490000;
+const uint64_t MAX_EXTRA_SIZE                                = 1024;
 
 const uint64_t MAX_TRANSACTION_SIZE_LIMIT                    = CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_CURRENT / 4 - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
 

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -73,6 +73,8 @@ const uint64_t MAX_TX_MIXIN_SIZE_V2                          = 20;
 const uint64_t MAX_TX_MIXIN_SIZE                             = MAX_TX_MIXIN_SIZE_V2;
 const uint32_t MIN_TX_MIXIN_V1_HEIGHT                        = 216245;
 const uint32_t MIN_TX_MIXIN_V2_HEIGHT                        = 216394;
+const uint32_t FEE_PER_BYTE_HEIGHT                           = 490000;
+
 const uint64_t MAX_TRANSACTION_SIZE_LIMIT                    = CRYPTONOTE_BLOCK_GRANTED_FULL_REWARD_ZONE_CURRENT / 4 - CRYPTONOTE_COINBASE_BLOB_RESERVED_SIZE;
 
 const size_t   DANDELION_EPOCH                               = 600;

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -792,6 +792,10 @@ uint64_t Blockchain::getMinimalFee(uint32_t height) {
     ++offset;
   }
 
+  /* Perhaps, in case of POW change, difficulties for calculations here
+   * should be reset and used starting from the fork height.
+   */
+
   // calculate average difficulty for ~last month
   uint64_t avgCurrentDifficulty = getAvgDifficulty(height, window * 7 * 4);
   // reference trailing average difficulty

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -1124,6 +1124,16 @@ bool Blockchain::prevalidate_miner_transaction(const Block& b, uint32_t height) 
     return false;
   }
 
+  uint64_t extraSize = (uint64_t)b.baseTransaction.extra.size();
+  if (height > CryptoNote::parameters::FEE_PER_BYTE_HEIGHT && extraSize > CryptoNote::parameters::MAX_EXTRA_SIZE) {
+    logger(ERROR, BRIGHT_RED)
+      << "The miner transaction extra is too large in block "
+      << get_block_hash(b) << ". Allowed: "
+      << CryptoNote::parameters::MAX_EXTRA_SIZE
+      << ", actual: " << extraSize << ".";
+    return false;
+  }
+
   return true;
 }
 

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -767,31 +767,6 @@ difficulty_type Blockchain::getAvgDifficulty(uint32_t height) {
   return m_blocks[std::min<difficulty_type>(height, m_blocks.size())].cumulative_difficulty / std::min<difficulty_type>(height, m_blocks.size());
 }
 
-difficulty_type Blockchain::getSMADifficulty(uint32_t height, size_t window) {
-  std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
-  height = std::min<uint32_t>(height, (uint32_t)m_blocks.size() - 1);
-  if (height <= 1)
-    return 1;
-
-  size_t offset;
-  offset = height - std::min<uint32_t>(height, std::min<uint32_t>(static_cast<uint32_t>(m_blocks.size() - 1), static_cast<uint32_t>(window)));
-  if (offset == 0) {
-    ++offset;
-  }
-
-  uint64_t cumulDiff = m_blocks[height].cumulative_difficulty - m_blocks[offset].cumulative_difficulty;
-  uint64_t solveTime = m_blocks[height].bl.timestamp - m_blocks[offset].bl.timestamp;
-  uint64_t adjWindow = std::min<uint32_t>(static_cast<uint32_t>(m_blocks.size() - 1), static_cast<uint32_t>(window));
-  uint64_t T         = CryptoNote::parameters::DIFFICULTY_TARGET;
-  uint64_t low, high;
-  low = mul128(cumulDiff, T, &high);
-  if (high != 0) {
-    return 0;
-  }
-
-  return low / (T * adjWindow / 2 + solveTime / 2);
-}
-
 uint64_t Blockchain::getBlockTimestamp(uint32_t height) {
   assert(height < m_blocks.size());
   return m_blocks[height].bl.timestamp;
@@ -818,8 +793,7 @@ uint64_t Blockchain::getMinimalFee(uint32_t height) {
   }
 
   // calculate average difficulty for ~last month
-  // In whitepaper here stands SMA
-  uint64_t avgCurrentSMADifficulty = getSMADifficulty(height, window * 7 * 4);
+  uint64_t avgCurrentDifficulty = getAvgDifficulty(height, window * 7 * 4);
   // reference trailing average difficulty
   uint64_t avgReferenceDifficulty = m_blocks[height].cumulative_difficulty / height;
   // calculate current base reward
@@ -827,7 +801,7 @@ uint64_t Blockchain::getMinimalFee(uint32_t height) {
   // reference trailing average reward
   uint64_t avgReferenceReward = m_blocks[height].already_generated_coins / height;
 
-  return m_currency.getMinimalFee(avgCurrentSMADifficulty, currentReward, avgReferenceDifficulty, avgReferenceReward, height);
+  return m_currency.getMinimalFee(avgCurrentDifficulty, currentReward, avgReferenceDifficulty, avgReferenceReward, height);
 }
 
 uint64_t Blockchain::getCoinsInCirculation() {

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -1125,7 +1125,7 @@ bool Blockchain::prevalidate_miner_transaction(const Block& b, uint32_t height) 
   }
 
   uint64_t extraSize = (uint64_t)b.baseTransaction.extra.size();
-  if (height > CryptoNote::parameters::FEE_PER_BYTE_HEIGHT && extraSize > CryptoNote::parameters::MAX_EXTRA_SIZE) {
+  if (height > CryptoNote::parameters::UPGRADE_HEIGHT_V4_2 && extraSize > CryptoNote::parameters::MAX_EXTRA_SIZE) {
     logger(ERROR, BRIGHT_RED)
       << "The miner transaction extra is too large in block "
       << get_block_hash(b) << ". Allowed: "

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -793,15 +793,15 @@ uint64_t Blockchain::getMinimalFee(uint32_t height) {
   }
 
   // calculate average difficulty for ~last month
-  uint64_t avgDifficultyCurrent = getAvgDifficulty(height, window * 7 * 4);
-  // historical reference trailing average difficulty
-  uint64_t avgDifficultyHistorical = m_blocks[height].cumulative_difficulty / height;
-  // calculate average reward for ~last day (base, excluding fees)
-  uint64_t avgRewardCurrent = (m_blocks[height].already_generated_coins - m_blocks[offset].already_generated_coins) / window;
-  // historical reference trailing average reward
-  uint64_t avgRewardHistorical = m_blocks[height].already_generated_coins / height;
+  uint64_t avgCurrentDifficulty = getAvgDifficulty(height, window * 7 * 4);
+  // reference trailing average difficulty
+  uint64_t avgReferenceDifficulty = m_blocks[height].cumulative_difficulty / height;
+  // calculate current base reward
+  uint64_t currentReward = m_currency.calculateReward(m_blocks[height].already_generated_coins);
+  // reference trailing average reward
+  uint64_t avgReferenceReward = m_blocks[height].already_generated_coins / height;
 
-  return m_currency.getMinimalFee(avgDifficultyCurrent, avgRewardCurrent, avgDifficultyHistorical, avgRewardHistorical, height);
+  return m_currency.getMinimalFee(avgCurrentDifficulty, currentReward, avgReferenceDifficulty, avgReferenceReward, height);
 }
 
 uint64_t Blockchain::getCoinsInCirculation() {

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -1089,19 +1089,19 @@ bool Blockchain::prevalidate_miner_transaction(const Block& b, uint32_t height) 
 
   if (!(b.baseTransaction.inputs.size() == 1)) {
     logger(ERROR, BRIGHT_RED)
-      << "coinbase transaction in the block has no inputs";
+      << "Coinbase transaction in the block has no inputs";
     return false;
   }
 
   if (!(b.baseTransaction.signatures.empty())) {
     logger(ERROR, BRIGHT_RED)
-      << "coinbase transaction in the block shouldn't have signatures";
+      << "Coinbase transaction in the block shouldn't have signatures";
     return false;
   }
 
   if (!(b.baseTransaction.inputs[0].type() == typeid(BaseInput))) {
     logger(ERROR, BRIGHT_RED)
-      << "coinbase transaction in the block has the wrong type";
+      << "Coinbase transaction in the block has the wrong type";
     return false;
   }
 
@@ -1113,14 +1113,14 @@ bool Blockchain::prevalidate_miner_transaction(const Block& b, uint32_t height) 
 
   if (!(b.baseTransaction.unlockTime == height + (b.majorVersion < BLOCK_MAJOR_VERSION_5 ? m_currency.minedMoneyUnlockWindow() : m_currency.minedMoneyUnlockWindow_v1()))) {
     logger(ERROR, BRIGHT_RED)
-      << "coinbase transaction transaction have wrong unlock time="
+      << "Coinbase transaction has wrong unlock time="
       << b.baseTransaction.unlockTime << ", expected "
       << height + (b.majorVersion < BLOCK_MAJOR_VERSION_5 ? m_currency.minedMoneyUnlockWindow() : m_currency.minedMoneyUnlockWindow_v1());
     return false;
   }
 
   if (!check_outs_overflow(b.baseTransaction)) {
-    logger(INFO, BRIGHT_RED) << "miner transaction have money overflow in block " << get_block_hash(b);
+    logger(ERROR, BRIGHT_RED) << "The miner transaction has money overflow in block " << get_block_hash(b);
     return false;
   }
 

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -94,7 +94,6 @@ namespace CryptoNote {
     difficulty_type getDifficultyForNextBlock();
     difficulty_type getAvgDifficulty(uint32_t height);
     difficulty_type getAvgDifficulty(uint32_t height, size_t window);
-    difficulty_type getSMADifficulty(uint32_t height, size_t window);
     uint64_t getBlockTimestamp(uint32_t height);
     uint64_t getMinimalFee(uint32_t height);
     uint64_t getCoinsInCirculation();

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -94,6 +94,7 @@ namespace CryptoNote {
     difficulty_type getDifficultyForNextBlock();
     difficulty_type getAvgDifficulty(uint32_t height);
     difficulty_type getAvgDifficulty(uint32_t height, size_t window);
+    difficulty_type getSMADifficulty(uint32_t height, size_t window);
     uint64_t getBlockTimestamp(uint32_t height);
     uint64_t getMinimalFee(uint32_t height);
     uint64_t getCoinsInCirculation();

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -278,19 +278,19 @@ bool Core::get_stat_info(core_stat_info& st_inf) {
   return true;
 }
 
-bool Core::check_tx_mixin(const Transaction& tx, uint32_t height) {
+bool Core::check_tx_mixin(const Transaction& tx, const Crypto::Hash& txHash, uint32_t height) {
   size_t inputIndex = 0;
   for (const auto& txin : tx.inputs) {
     assert(inputIndex < tx.signatures.size());
     if (txin.type() == typeid(KeyInput)) {
       uint64_t txMixin = boost::get<KeyInput>(txin).outputIndexes.size();
-      if ((height > CryptoNote::parameters::MIN_TX_MIXIN_HEIGHT &&
+      if ((height > CryptoNote::parameters::UPGRADE_HEIGHT_V3_1 &&
            txMixin > CryptoNote::parameters::MAX_TX_MIXIN_SIZE)) {
-        logger(ERROR) << "Transaction " << getObjectHash(tx) << " has too large mixIn count, rejected";
+        logger(ERROR) << "Transaction " << Common::podToHex(txHash) << " has too large mixIn count, rejected";
         return false;
       }
       if (getCurrentBlockMajorVersion() >= BLOCK_MAJOR_VERSION_4 && txMixin < m_currency.minMixin() && txMixin != 1) {
-        logger(ERROR) << "Transaction " << getObjectHash(tx) << " has mixIn count below the required minimum, rejected";
+        logger(ERROR) << "Transaction " << Common::podToHex(txHash) << " has mixIn count below the required minimum, rejected";
         return false;
       }
       ++inputIndex;
@@ -299,7 +299,7 @@ bool Core::check_tx_mixin(const Transaction& tx, uint32_t height) {
   return true;
 }
 
-bool Core::check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_context& tvc, uint32_t height) {
+bool Core::check_tx_fee(const Transaction& tx, const Crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, uint32_t height) {
   uint64_t inputs_amount = 0;
   if (!get_inputs_money_amount(tx, inputs_amount)) {
     tvc.m_verification_failed = true;
@@ -315,41 +315,40 @@ bool Core::check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_
     return false;
   }
 
-  // tx extra size in bytes, uint8_t is a one byte
-  uint64_t extraSize = (uint64_t)tx.extra.size();
-
-  // To prevent blockchain bloat it's possible to just limit max tx extra size
-  // or charge fee per byte for the size exceeding free limit, 100 bytes is
-  // enough to contain data of the ordinary tx (public key, payment id, etc.)
-
-  Crypto::Hash h = NULL_HASH;
-  getObjectHash(tx, h, blobSize);
   const uint64_t fee = inputs_amount - outputs_amount;
   bool isFusionTransaction = fee == 0 && m_currency.isFusionTransaction(tx, blobSize, height);
-  bool enough = true;
-  if (!isFusionTransaction && !m_checkpoints.is_in_checkpoint_zone(getCurrentBlockchainHeight())) {
-    if (getBlockMajorVersionForHeight(height) < BLOCK_MAJOR_VERSION_4) {
-      if (fee < CryptoNote::parameters::MINIMUM_FEE_V1) {
-        logger(INFO) << "[Core] Transaction fee is not enough: " << m_currency.formatAmount(fee) << ", minimum fee: " << m_currency.formatAmount(CryptoNote::parameters::MINIMUM_FEE_V1);
-        enough = false;
-      }
-    } else {
+  if (!isFusionTransaction && !m_checkpoints.is_in_checkpoint_zone(height)) {
+    bool enough = true;
+
+    if (height < CryptoNote::parameters::UPGRADE_HEIGHT_V3_1 && fee < CryptoNote::parameters::MINIMUM_FEE_V1 ||
+        height > CryptoNote::parameters::UPGRADE_HEIGHT_V3_1 && height <= CryptoNote::parameters::UPGRADE_HEIGHT_V4 && fee < CryptoNote::parameters::MINIMUM_FEE_V2)
+    {
+      enough = false;
+    }
+    else if (height > CryptoNote::parameters::UPGRADE_HEIGHT_V4) {
       uint64_t min = getMinimalFeeForHeight(height);
 
-      if (height > CryptoNote::parameters::FEE_PER_BYTE_HEIGHT) {
-        uint64_t feePerByte = m_currency.getFeePerByte(extraSize, min);
-        min += feePerByte;
-      }
-
-      if (fee < (min - min * 20 / 100)) {
-        logger(INFO) << "[Core] Transaction fee is not enough: " << m_currency.formatAmount(fee) << ", minimum fee: " << m_currency.formatAmount(min);
+      if (fee < (min - (min * 20 / 100))) {      
         enough = false;
       }
+
+      if (height > CryptoNote::parameters::UPGRADE_HEIGHT_V4_2) {
+        uint64_t extraSize = (uint64_t)tx.extra.size();
+        uint64_t feePerByte = m_currency.getFeePerByte(extraSize, min);
+        min += feePerByte;
+        if (fee < (min - min * 20 / 100)) {
+          logger(DEBUGGING) << "Transaction fee is insufficient due to additional data in extra";
+          enough = false;
+        }
+      }
     }
 
-    if (!enough) {
+    if (!enough) {     
       tvc.m_verification_failed = true;
       tvc.m_tx_fee_too_small = true;
+      logger(DEBUGGING) << "The fee for transaction " 
+                        << Common::podToHex(txHash) 
+                        << " is insufficient and it is not a fusion transaction";
       return false;
     }
   }
@@ -357,24 +356,24 @@ bool Core::check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_
   return true;
 }
 
-bool Core::check_tx_unmixable(const Transaction& tx, uint32_t height) {
+bool Core::check_tx_unmixable(const Transaction& tx, const Crypto::Hash& txHash, uint32_t height) {
   for (const auto& out : tx.outputs) {
-    if (height >= CryptoNote::parameters::FEE_PER_BYTE_HEIGHT && !is_valid_decomposed_amount(out.amount)) {
-      logger(ERROR) << "Invalid decomposed output amount " << out.amount << " for tx id= " << getObjectHash(tx);
+    if (height >= CryptoNote::parameters::UPGRADE_HEIGHT_V4_2 && !is_valid_decomposed_amount(out.amount)) {
+      logger(ERROR) << "Invalid decomposed output amount " << out.amount << " for tx id= " << Common::podToHex(txHash);
       return false;
     }
   }
   return true;
 }
 
-bool Core::check_tx_semantic(const Transaction& tx, bool keeped_by_block) {
+bool Core::check_tx_semantic(const Transaction& tx, const Crypto::Hash& txHash, bool keeped_by_block) {
   if (!tx.inputs.size()) {
-    logger(ERROR) << "tx with empty inputs, rejected for tx id= " << getObjectHash(tx);
+    logger(ERROR) << "tx with empty inputs, rejected for tx id= " << Common::podToHex(txHash);
     return false;
   }
 
   if (tx.inputs.size() != tx.signatures.size()) {
-    logger(ERROR) << "tx signatures size doesn't match inputs size, rejected for tx id= " << getObjectHash(tx);
+    logger(ERROR) << "tx signatures size doesn't match inputs size, rejected for tx id= " << Common::podToHex(txHash);
     return false;
   }
 
@@ -382,25 +381,25 @@ bool Core::check_tx_semantic(const Transaction& tx, bool keeped_by_block) {
     if (tx.inputs[i].type() == typeid(KeyInput)) {
       if (boost::get<KeyInput>(tx.inputs[i]).outputIndexes.size() != tx.signatures[i].size()) {
         logger(ERROR) << "tx signatures count doesn't match outputIndexes count for input " 
-          << i << ", rejected for tx id= " << getObjectHash(tx);
+          << i << ", rejected for tx id= " << Common::podToHex(txHash);
         return false;
       }
     }
   }
 
   if (!check_inputs_types_supported(tx)) {
-    logger(ERROR) << "unsupported input types for tx id= " << getObjectHash(tx);
+    logger(ERROR) << "unsupported input types for tx id= " << Common::podToHex(txHash);
     return false;
   }
 
   std::string errmsg;
   if (!check_outs_valid(tx, &errmsg)) {
-    logger(ERROR) << "tx with invalid outputs, rejected for tx id= " << getObjectHash(tx) << ": " << errmsg;
+    logger(ERROR) << "tx with invalid outputs, rejected for tx id= " << Common::podToHex(txHash) << ": " << errmsg;
     return false;
   }
 
   if (!check_money_overflow(tx)) {
-    logger(ERROR) << "tx have money overflow, rejected for tx id= " << getObjectHash(tx);
+    logger(ERROR) << "tx have money overflow, rejected for tx id= " << Common::podToHex(txHash);
     return false;
   }
 
@@ -409,7 +408,7 @@ bool Core::check_tx_semantic(const Transaction& tx, bool keeped_by_block) {
   uint64_t amount_out = get_outs_money_amount(tx);
 
   if (amount_in < amount_out) {
-    logger(ERROR) << "tx with wrong amounts: ins " << amount_in << ", outs " << amount_out << ", rejected for tx id= " << getObjectHash(tx);
+    logger(ERROR) << "tx with wrong amounts: ins " << amount_in << ", outs " << amount_out << ", rejected for tx id= " << Common::podToHex(txHash);
     return false;
   }
 
@@ -780,7 +779,7 @@ bool Core::parse_tx_from_blob(Transaction& tx, Crypto::Hash& tx_hash, Crypto::Ha
   return parseAndValidateTransactionFromBinaryArray(blob, tx, tx_hash, tx_prefix_hash);
 }
 
-bool Core::check_tx_syntax(const Transaction& tx) {
+bool Core::check_tx_syntax(const Transaction& tx, const Crypto::Hash& tx_hash) {
   return true;
 }
 
@@ -1238,7 +1237,7 @@ bool Core::getPaymentId(const Transaction& transaction, Crypto::Hash& paymentId)
 }
 
 bool Core::handleIncomingTransaction(const Transaction& tx, const Crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, bool keptByBlock, uint32_t height) {
-  if (!check_tx_syntax(tx)) {
+  if (!check_tx_syntax(tx, txHash)) {
     logger(INFO) << "WRONG TRANSACTION BLOB, Failed to check tx " << txHash << " syntax, rejected";
     tvc.m_verification_failed = true;
     return false;
@@ -1252,26 +1251,26 @@ bool Core::handleIncomingTransaction(const Transaction& tx, const Crypto::Hash& 
       return false;
     }
   
-    if (!check_tx_fee(tx, blobSize, tvc, height)) {
+    if (!check_tx_fee(tx, txHash, blobSize, tvc, height)) {
       tvc.m_verification_failed = true;
       return false;
     }
 
-    if (!check_tx_mixin(tx, height)) {
+    if (!check_tx_mixin(tx, txHash, height)) {
       logger(INFO) << "Transaction verification failed: mixin count for transaction " << txHash << " is too large, rejected";
       tvc.m_verification_failed = true;
       return false;
     }
 
-    if (!check_tx_unmixable(tx, height)) {
+    if (!check_tx_unmixable(tx, txHash, height)) {
       logger(ERROR) << "Transaction verification failed: unmixable output for transaction " << txHash << ", rejected";
       tvc.m_verification_failed = true;
       return false;
-	}
+    }
 
   }
 
-  if (!check_tx_semantic(tx, keptByBlock)) {
+  if (!check_tx_semantic(tx, txHash, keptByBlock)) {
     logger(INFO) << "WRONG TRANSACTION BLOB, Failed to check tx " << txHash << " semantic, rejected";
     tvc.m_verification_failed = true;
     return false;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -320,7 +320,7 @@ bool Core::check_tx_fee(const Transaction& tx, const Crypto::Hash& txHash, size_
   if (!isFusionTransaction && !m_checkpoints.is_in_checkpoint_zone(height)) {
     bool enough = true;
 
-    if (height < CryptoNote::parameters::UPGRADE_HEIGHT_V3_1 && fee < CryptoNote::parameters::MINIMUM_FEE_V1 ||
+    if (height <= CryptoNote::parameters::UPGRADE_HEIGHT_V3_1 && fee < CryptoNote::parameters::MINIMUM_FEE_V1 ||
         height > CryptoNote::parameters::UPGRADE_HEIGHT_V3_1 && height <= CryptoNote::parameters::UPGRADE_HEIGHT_V4 && fee < CryptoNote::parameters::MINIMUM_FEE_V2)
     {
       enough = false;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -318,6 +318,13 @@ bool Core::check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_
     return false;
   }
 
+  // tx extra size in bytes, uint8_t is a one byte
+  uint64_t extraSize = tx.extra.size();
+
+  // It is possible to just limit max tx extra size e.g. to prevent abuse
+  // (blockchain bloat) or charge fee per byte above min free size of extra,
+  // 0.1 Kb is enough to contain data of ordinary tx (payment id, nonce etc.)
+
   Crypto::Hash h = NULL_HASH;
   getObjectHash(tx, h, blobSize);
   const uint64_t fee = inputs_amount - outputs_amount;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -284,11 +284,8 @@ bool Core::check_tx_mixin(const Transaction& tx, uint32_t height) {
     assert(inputIndex < tx.signatures.size());
     if (txin.type() == typeid(KeyInput)) {
       uint64_t txMixin = boost::get<KeyInput>(txin).outputIndexes.size();
-      if ((height > CryptoNote::parameters::MIN_TX_MIXIN_V1_HEIGHT &&
-           height < CryptoNote::parameters::MIN_TX_MIXIN_V2_HEIGHT &&
-           txMixin > CryptoNote::parameters::MAX_TX_MIXIN_SIZE_V1) ||
-          (height > CryptoNote::parameters::MIN_TX_MIXIN_V2_HEIGHT &&
-           txMixin > CryptoNote::parameters::MAX_TX_MIXIN_SIZE_V2)) {
+      if ((height > CryptoNote::parameters::MIN_TX_MIXIN_HEIGHT &&
+           txMixin > CryptoNote::parameters::MAX_TX_MIXIN_SIZE)) {
         logger(ERROR) << "Transaction " << getObjectHash(tx) << " has too large mixIn count, rejected";
         return false;
       }
@@ -362,7 +359,7 @@ bool Core::check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_
 
 bool Core::check_tx_unmixable(const Transaction& tx, uint32_t height) {
   for (const auto& out : tx.outputs) {
-    if (!is_valid_decomposed_amount(out.amount) && height >= CryptoNote::parameters::UPGRADE_HEIGHT_V5) {
+    if (height >= CryptoNote::parameters::FEE_PER_BYTE_HEIGHT && !is_valid_decomposed_amount(out.amount)) {
       logger(ERROR) << "Invalid decomposed output amount " << out.amount << " for tx id= " << getObjectHash(tx);
       return false;
     }

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -343,7 +343,7 @@ bool Core::check_tx_fee(const Transaction& tx, const Crypto::Hash& txHash, size_
       }
     }
 
-    if (!enough) {     
+    if (!enough) {
       tvc.m_verification_failed = true;
       tvc.m_tx_fee_too_small = true;
       logger(DEBUGGING) << "The fee for transaction " 

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -189,15 +189,15 @@ namespace CryptoNote {
      bool load_state_data();
      bool parse_tx_from_blob(Transaction& tx, Crypto::Hash& tx_hash, Crypto::Hash& tx_prefix_hash, const BinaryArray& blob);
 
-     bool check_tx_syntax(const Transaction& tx);
+     bool check_tx_syntax(const Transaction& txc, const Crypto::Hash& txHash);
      //check correct values, amounts and all lightweight checks not related with database
-     bool check_tx_semantic(const Transaction& tx, bool keeped_by_block);
+     bool check_tx_semantic(const Transaction& tx, const Crypto::Hash& txHash, bool keeped_by_block);
      //check if tx already in memory pool or in main blockchain
-     bool check_tx_mixin(const Transaction& tx, uint32_t height);
+     bool check_tx_mixin(const Transaction& tx, const Crypto::Hash& txHash, uint32_t height);
      //check if the mixin is not too large
-     virtual bool check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_context& tvc, uint32_t height) override;
+     virtual bool check_tx_fee(const Transaction& tx, const Crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, uint32_t height) override;
      //check if tx is not sending unmixable outputs
-     bool check_tx_unmixable(const Transaction& tx, uint32_t height);
+     bool check_tx_unmixable(const Transaction& tx, const Crypto::Hash& txHash, uint32_t height);
 
      bool update_miner_block_template();
      bool handle_command_line(const boost::program_options::variables_map& vm);

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -409,13 +409,13 @@ namespace CryptoNote {
                                     pow(2, static_cast<double>(height) / static_cast<double>(blocksInTwoYears));
     minFee = baseFee * static_cast<double>(avgReferenceDifficulty) / currentDifficultyMoore *
              static_cast<double>(currentReward) / static_cast<double>(avgReferenceReward);
-    
+
     // zero test 
     if (minFee == 0 || !std::isfinite(minFee))
       return CryptoNote::parameters::MAXIMUM_FEE;
 
     minimumFee = static_cast<uint64_t>(minFee);
-        
+
     if (height > CryptoNote::parameters::UPGRADE_HEIGHT_V5) {
       // Make all insignificant digits zero
       uint64_t i = 1000000000;

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -403,7 +403,7 @@ namespace CryptoNote {
   uint64_t Currency::getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t currentReward, uint64_t avgReferenceDifficulty, uint64_t avgReferenceReward, uint32_t height) const {
     uint64_t minimumFee(0);
     double minFee(0.0);
-    const double baseFee = height <= CryptoNote::parameters::FEE_PER_BYTE_HEIGHT ? static_cast<double>(250000000000) : static_cast<double>(50000000000);
+    const double baseFee = static_cast<double>(250000000000);
     const uint64_t blocksInTwoYears = expectedNumberOfBlocksPerDay() * 365 * 2;
     double currentDifficultyMoore = static_cast<double>(avgCurrentDifficulty) / 
                                     pow(2, static_cast<double>(height) / static_cast<double>(blocksInTwoYears));

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -403,7 +403,7 @@ namespace CryptoNote {
   uint64_t Currency::getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t currentReward, uint64_t avgReferenceDifficulty, uint64_t avgReferenceReward, uint32_t height) const {
     uint64_t minimumFee(0);
     double minFee(0.0);
-    const double baseFee = height <= CryptoNote::parameters::FEE_PER_BYTE_HEIGHT ? static_cast<double>(250000000000) : static_cast<double>(25000000000); // it must have been supposed to be 0.025
+    const double baseFee = height <= CryptoNote::parameters::FEE_PER_BYTE_HEIGHT ? static_cast<double>(250000000000) : static_cast<double>(50000000000);
     const uint64_t blocksInTwoYears = expectedNumberOfBlocksPerDay() * 365 * 2;
     double currentDifficultyMoore = static_cast<double>(avgCurrentDifficulty) / 
                                     pow(2, static_cast<double>(height) / static_cast<double>(blocksInTwoYears));

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -403,7 +403,7 @@ namespace CryptoNote {
   uint64_t Currency::getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t currentReward, uint64_t avgReferenceDifficulty, uint64_t avgReferenceReward, uint32_t height) const {
     uint64_t minimumFee(0);
     double minFee(0.0);
-    const double baseFee = static_cast<double>(250000000000); // why then the limit in the end is 100000000000, it must have been supposed to be 0.025??
+    const double baseFee = height <= CryptoNote::parameters::FEE_PER_BYTE_HEIGHT ? static_cast<double>(250000000000) : static_cast<double>(25000000000); // it must have been supposed to be 0.025
     const uint64_t blocksInTwoYears = expectedNumberOfBlocksPerDay() * 365 * 2;
     double currentDifficultyMoore = static_cast<double>(avgCurrentDifficulty) / 
                                     pow(2, static_cast<double>(height) / static_cast<double>(blocksInTwoYears));

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -416,7 +416,7 @@ namespace CryptoNote {
 
     minimumFee = static_cast<uint64_t>(minFee);
 
-    if (height > CryptoNote::parameters::FEE_PER_BYTE_HEIGHT) {
+    if (height > CryptoNote::parameters::UPGRADE_HEIGHT_V4_2) {
       // Make all insignificant digits zero
       uint64_t i = 1000000000;
       while (i > 1) {
@@ -651,7 +651,7 @@ namespace CryptoNote {
 
 		int64_t max_TS, prev_max_TS;
 		prev_max_TS = timestamps[0];
-		uint32_t lwma3_height = CryptoNote::parameters::UPGRADE_HEIGHT_LWMA3;
+		uint32_t lwma3_height = CryptoNote::parameters::UPGRADE_HEIGHT_V4_1;
 		
 		for (int64_t i = 1; i <= N; i++) {
 			if (height < lwma3_height) { // LWMA-2

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -400,22 +400,16 @@ namespace CryptoNote {
   // The idea is based on Zawy's post
   // http://zawy1.blogspot.com/2017/12/using-difficulty-to-get-constant-value.html
   // Moore's law application by Sergey Kozlov
-  uint64_t Currency::getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t avgCurrentReward, uint64_t avgHistoricDifficulty, uint64_t avgHistoricReward, uint32_t height) const {
+  uint64_t Currency::getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t currentReward, uint64_t avgReferenceDifficulty, uint64_t avgReferenceReward, uint32_t height) const {
     uint64_t minimumFee(0);
     double minFee(0.0);
-    const double gauge = double(0.25);
-    const double baseFee = static_cast<double>(CryptoNote::parameters::MAXIMUM_FEE);
-
-    if (height <= CryptoNote::parameters::UPGRADE_HEIGHT_V5) {
-      const uint64_t blocksInTwoYears = expectedNumberOfBlocksPerDay() * 365 * 2;
-      double dailyDifficultyMoore = static_cast<double>(avgCurrentDifficulty) / pow(2, static_cast<double>(height) / static_cast<double>(blocksInTwoYears));
-      minFee = gauge * CryptoNote::parameters::COIN * static_cast<double>(avgHistoricDifficulty) /
-        dailyDifficultyMoore * static_cast<double>(avgCurrentReward) / static_cast<double>(avgHistoricReward);
-    }
-    else {
-      minFee = baseFee * static_cast<double>(avgHistoricDifficulty) / static_cast<double>(avgCurrentDifficulty) * static_cast<double>(avgCurrentReward) / static_cast<double>(avgHistoricReward);
-    }
-
+    const double baseFee = static_cast<double>(250000000000); // why then the limit in the end is 100000000000, it must have been supposed to be 0.025??
+    const uint64_t blocksInTwoYears = expectedNumberOfBlocksPerDay() * 365 * 2;
+    double currentDifficultyMoore = static_cast<double>(avgCurrentDifficulty) / 
+                                    pow(2, static_cast<double>(height) / static_cast<double>(blocksInTwoYears));
+    minFee = baseFee * static_cast<double>(avgReferenceDifficulty) / currentDifficultyMoore *
+             static_cast<double>(currentReward) / static_cast<double>(avgReferenceReward);
+    
     // zero test 
     if (minFee == 0 || !std::isfinite(minFee))
       return CryptoNote::parameters::MAXIMUM_FEE;

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -159,9 +159,10 @@ namespace CryptoNote {
       // flat rate tail emission reward,
       // inflation slowly diminishing in relation to supply
       //baseReward = CryptoNote::parameters::TAIL_EMISSION_REWARD;
-
+      // changed to
       // Friedman's k-percent rule,
       // inflation 2% of total coins in circulation per year
+      // according to Whitepaper v. 1, p. 16 (with change of 1% to 2%)
       const uint64_t blocksInOneYear = expectedNumberOfBlocksPerDay() * 365;
       uint64_t twoPercentOfEmission = static_cast<uint64_t>(static_cast<double>(alreadyGeneratedCoins) / 100.0 * 2.0);
       baseReward = twoPercentOfEmission / blocksInOneYear;
@@ -396,7 +397,7 @@ namespace CryptoNote {
 		return Common::Format::parseAmount(str, amount);
 	}
 
-  // Copyright (c) 2017-2018 Zawy 
+  // The idea is based on Zawy's post
   // http://zawy1.blogspot.com/2017/12/using-difficulty-to-get-constant-value.html
   // Moore's law application by Sergey Kozlov
   uint64_t Currency::getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t avgCurrentReward, uint64_t avgHistoricDifficulty, uint64_t avgHistoricReward, uint32_t height) const {

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -416,7 +416,7 @@ namespace CryptoNote {
 
     minimumFee = static_cast<uint64_t>(minFee);
 
-    if (height > CryptoNote::parameters::UPGRADE_HEIGHT_V5) {
+    if (height > CryptoNote::parameters::FEE_PER_BYTE_HEIGHT) {
       // Make all insignificant digits zero
       uint64_t i = 1000000000;
       while (i > 1) {

--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -425,6 +425,12 @@ namespace CryptoNote {
     return std::min<uint64_t>(CryptoNote::parameters::MAXIMUM_FEE, minimumFee);
   }
 
+  // All that exceeds 100 bytes is charged per byte,
+  // the cost of one byte is 1/100 of minimal fee
+  uint64_t Currency::getFeePerByte(const uint64_t txExtraSize, const uint64_t minFee) const {
+    return txExtraSize > 100 ? minFee / 100 * (txExtraSize - 100) : 0;
+  }
+
 	uint64_t Currency::roundUpMinFee(uint64_t minimalFee, int digits) const {
 		uint64_t ret(0);
 		std::string minFeeString = formatAmount(minimalFee);

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -81,7 +81,7 @@ public:
   uint64_t coin() const { return m_coin; }
 
   uint64_t minimumFee() const { return m_minimumFee; }
-  uint64_t getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t avgCurrentReward, uint64_t avgHistoricDifficulty, uint64_t avgHistoricReward, uint32_t height) const;
+  uint64_t getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t currentReward, uint64_t avgReferenceDifficulty, uint64_t avgReferenceReward, uint32_t height) const;
   uint64_t getFeePerByte(const uint64_t txExtraSize, const uint64_t minFee) const;
 
   uint64_t defaultDustThreshold() const { return m_defaultDustThreshold; }

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -82,6 +82,8 @@ public:
 
   uint64_t minimumFee() const { return m_minimumFee; }
   uint64_t getMinimalFee(uint64_t avgCurrentDifficulty, uint64_t avgCurrentReward, uint64_t avgHistoricDifficulty, uint64_t avgHistoricReward, uint32_t height) const;
+  uint64_t getFeePerByte(const uint64_t txExtraSize, const uint64_t minFee) const;
+
   uint64_t defaultDustThreshold() const { return m_defaultDustThreshold; }
 
   uint64_t difficultyTarget() const { return m_difficultyTarget; }

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -143,6 +143,7 @@ public:
   const Block& genesisBlock() const { return m_genesisBlock; }
   const Crypto::Hash& genesisBlockHash() const { return m_genesisBlockHash; }
 
+  uint64_t calculateReward(uint64_t alreadyGeneratedCoins) const;
   bool getBlockReward(uint8_t blockMajorVersion, size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee,
     uint64_t& reward, int64_t& emissionChange) const;
   size_t maxBlockCumulativeSize(uint64_t height) const;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -123,7 +123,7 @@ public:
   virtual uint64_t getMinimalFee() = 0;
   virtual uint64_t getNextBlockDifficulty() = 0;
   virtual uint64_t getTotalGeneratedAmount() = 0;
-  virtual bool check_tx_fee(const Transaction& tx, size_t blobSize, tx_verification_context& tvc, uint32_t height) = 0;
+  virtual bool check_tx_fee(const Transaction& tx, const Crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, uint32_t height) = 0;
   virtual size_t getPoolTransactionsCount() = 0;
   virtual size_t getBlockchainTotalTransactions() = 0;
   virtual uint32_t getCurrentBlockchainHeight() = 0;

--- a/src/CryptoNoteCore/TransactionPool.cpp
+++ b/src/CryptoNoteCore/TransactionPool.cpp
@@ -425,8 +425,8 @@ namespace CryptoNote {
       }
 
       tx_verification_context tvc = boost::value_initialized<tx_verification_context>();
-      if (!m_core.check_tx_fee(txd.tx, txd.blobSize, tvc, m_core.getCurrentBlockchainHeight())) {
-        logger(DEBUGGING) << "Transaction " << txd.id << " not included to block template because fee is too small";
+      if (!m_core.check_tx_fee(txd.tx, getObjectHash(txd.tx), txd.blobSize, tvc, m_core.getCurrentBlockchainHeight())) {
+        logger(DEBUGGING) << "Transaction " << txd.id << " not included to block template because fee is insufficient";
         continue;
       }
 

--- a/src/Serialization/BlockchainExplorerDataSerialization.cpp
+++ b/src/Serialization/BlockchainExplorerDataSerialization.cpp
@@ -137,6 +137,7 @@ void serialize(TransactionExtraDetails2& extra, ISerializer& serializer) {
   serializePod(extra.publicKey, "publicKey", serializer);
   serializer(extra.nonce, "nonce");
   serializeAsBinary(extra.raw, "raw", serializer);
+  serializer(extra.size, "size");
 }
 
 void serialize(TransactionDetails& transaction, ISerializer& serializer) {


### PR DESCRIPTION
## Rationale

A CryptoNote transaction has an `extra` field that can store additional information that is stored forever in the blockchain along with the transaction. There is no any limit of the size of this additional transaction `extra`, therefore it can potentially be quite large. We believe that permanent blockchain storage of the extra data, unrelated to the main purpose of transactions per se, namely, storing information about the transfer of money, has to be paid for. The problem is that the size of the transaction has no influence on the fee of the transaction.

Let us remind, what transaction fees are for. Unlike Bitcoin and Bitcoin-based coins, in CryptoNote protocol there is a mandatory minimal transaction fee which is either flat-rate fee in the default CryptoNote solution or size-based like in Monero. The minimum transaction fee solves three problems, - it introduces the costs of spamming the network, helps to motivate miners to continue to support the network and is preventing a transaction flooding traceability attack. This means that the minimum transaction fee can not be too low, as we saw in practice in the spam attack on Karbo network during the beginning of April 2018. The minimum fee was merely 0.0001 KRB ($0,00005) at the time of the attack! Karbo developers were forced to set higher transaction fees (0.1 KRB) to stop and prevent spamming. Karbo has introduced adaptive minimal transaction fees afterwards. It is important to make sure that the algorithm can not lower the minimum transaction fees too low enabling spam again.

In Monero, the most known CryptoNote based coin, the fees are based on transaction size, which solves this problem but creates another one - if a user sends a transaction with many outputs it will render a larger fee amount because of the larger size of the transaction. This is unfair and hard to understand by non-tech-savvy users: why a user has to pay more fees merely because, e.g. he received his money in many smaller transactions or, for example, he wants to send funds in one transaction to many recipients? After the improvement of the RingCT in Monero, the transaction sizes are significantly reduced and this problem generally is solved. But in Karbo the number of inputs/outputs has an influence on transaction size and this approach is not a good option.

In Karbo, as well as other coins based on the Bytecoin flavour of the CryptoNote, there is a special type of fee-less transactions, called a *'fusion transaction'*, which allows to optimize wallet - reduce the number of wallet inputs, resulting in smaller transactions. This solution was created to reduce the size of a transaction so it can fit into the block and transaction size limit but can be used to reduce the severity of the problem as well if we choose to use Monero's approach and introduce fees for the size of the transaction, however requiring additional steps in form of wallet optimization before sending a transaction, which undermines usability.

## Charge for extra size

We propose a different solution: calculate the additional fee only for the size of the `extra` field of the transaction instead of the whole transaction. Let's call this fee as *'fee per byte'*. This way, the normal transactions will all have the same obligatory limit of the *'minimal fee'* but for the additional data, the sender will have to pay an extra fee based on the size of the extra data.

The `extra` field of any normal transaction always contains or may contain some data, like e.g. payment id. The size of the `extra` field of the typical transaction fits in 100 bytes, therefore this size of the `extra` field of the transaction is proposed to be free of charge.

The `extra` field is the vector of uint8_t, and the uint8_t is exactly the one byte, therefore we can easily get the size of the `extra` field, being the size of the vector, and calculate the *'fee per byte'*, excluding first 100 bytes.

The cost of one byte of the `extra` is set as 1/100 of the *'minimal transaction fee'*.
The *'fee per byte'* is added to the 'minimal transaction fee'. The total transaction fee is calculated as

F = Fb + Fm

where Fb is *'fee per byte'* and Fm is *'minimal transaction fee'*.

## Additional thoughts

The fees for the extra size are received by the miners whereas the size impacts the nodes storing the blockchain in the first place, however indirectly it benefits the whole system including nodes, so in the absence of a better solution, this is the only viable option available.

To allow to attach as many data as user wants for a fee, the removal of limits on transaction size is probably required, which is questionable because this limit is set for protection from:

1) transactions too large to fit into the block;
2) from transactions so large due to many inputs/outputs that are too hard to process on the ordinary PCs; a really large number of outputs can be used for spam (e.g. for traceability attack).

The first problem can be solved by removing of the limit of the block size (the later limit is not hard and can adapt but it does not change rapidly). Alternatively, and probably preferably, user who wants to put into the block a large transaction just has to pay enough fee to the miner that covers the block reward penalty which reduces the block reward it the block size is exceeding current median.

To solve the second problem we could replace the transaction size limit by the limits of the number of the inputs/outputs (as it is done in Monero, where they limit the number of outputs to 16 per transaction). However, the limit of outputs, in turn, makes entirely impossible or hampers a genuine usage, such as payouts from pools or faucets to many users in a single transaction to save on fees.