### PR TITLE
Add REST-like API for daemon

### DIFF
--- a/src/Common/Math.h
+++ b/src/Common/Math.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <vector>
+#include "StringTools.h"
 
 namespace Common {
 
@@ -38,6 +39,96 @@ T medianValue(std::vector<T> &v) {
   } else { //2, 4, 6...
     return (v[n - 1] + v[n]) / 2;
   }
+}
+
+template<typename Target, typename Source>
+void integer_cast_throw(const Source &arg) {
+  throw std::out_of_range("Cannot convert value " + Common::toString(arg) + " to integer in range [" +
+    Common::toString(std::numeric_limits<Target>::min()) + ".." +
+    Common::toString(std::numeric_limits<Target>::max()) + "]");
+}
+
+template<typename Target, typename Source>
+inline Target integer_cast_impl(const Source &arg, std::true_type, std::true_type) {
+  // both unsigned
+  if (arg > std::numeric_limits<Target>::max())
+    integer_cast_throw<Target>(arg);
+  return static_cast<Target>(arg);
+}
+
+template<typename Target, typename Source>
+inline Target integer_cast_impl(const Source &arg, std::false_type, std::false_type) {
+  // both signed
+  if (arg > std::numeric_limits<Target>::max())
+    integer_cast_throw<Target>(arg);
+  if (arg < std::numeric_limits<Target>::min())
+    integer_cast_throw<Target>(arg);
+  return static_cast<Target>(arg);
+}
+
+template<typename Target, typename Source>
+inline Target integer_cast_impl(const Source &arg, std::true_type, std::false_type) {
+  // signed to unsigned
+  typedef typename std::make_unsigned<Source>::type USource;
+  if (arg < 0)
+    integer_cast_throw<Target>(arg);
+  if (static_cast<USource>(arg) > std::numeric_limits<Target>::max())
+    integer_cast_throw<Target>(arg);
+  return static_cast<Target>(arg);
+}
+
+template<typename Target, typename Source>
+inline Target integer_cast_impl(const Source &arg, std::false_type, std::true_type) {
+  // unsigned to signed
+  typedef typename std::make_unsigned<Target>::type UTarget;
+  if (arg > static_cast<UTarget>(std::numeric_limits<Target>::max()))
+    integer_cast_throw<Target>(arg);
+  return static_cast<Target>(arg);
+}
+
+template<typename Target, typename Source>  // source integral
+inline Target integer_cast_is_integral(const Source &arg, std::true_type) {
+  return integer_cast_impl<Target, Source>(arg, std::is_unsigned<Target>{}, std::is_unsigned<Source>{});
+}
+
+inline bool has_sign(const std::string &arg) {
+  size_t pos = 0;
+  while (pos != arg.size() && isspace(arg[pos]))
+    pos += 1;
+  return pos != arg.size() && arg[pos] == '-';
+}
+
+inline bool has_tail(const std::string &arg, size_t &pos) {
+  while (pos != arg.size() && isspace(arg[pos]))
+    pos += 1;
+  return pos != arg.size();
+}
+
+template<typename Target, typename Source>  // source not integral (string convertible)
+inline Target integer_cast_is_integral(const Source &arg, std::false_type) {
+  const std::string &sarg = arg;          // creates tmp object if neccessary
+  if (std::is_unsigned<Target>::value) {  // Crazy stupid C++ standard :(
+    if (has_sign(sarg))
+      throw std::out_of_range("Cannot convert string '" + sarg + "' to integer, must be >= 0");
+    size_t pos = 0;
+    auto val = std::stoull(sarg, &pos);
+    if (has_tail(sarg, pos))
+      throw std::out_of_range("Cannot convert string '" + sarg + "' to integer, excess characters not allowed");
+    return integer_cast_is_integral<Target>(val, std::true_type{});
+  }
+  size_t pos = 0;
+  auto val = std::stoll(sarg, &pos);
+  if (has_tail(sarg, pos))
+    throw std::out_of_range("Cannot convert string '" + sarg + "' to integer, excess characters '" +
+      sarg.substr(pos) + "' not allowed");
+  return integer_cast_is_integral<Target>(val, std::true_type{});
+}
+
+template<typename Target, typename Source>
+inline Target integer_cast(const Source &arg) {
+  static_assert(
+    std::is_integral<Target>::value, "Target type must be integral, source either integral or string convertible");
+  return integer_cast_is_integral<Target, Source>(arg, std::is_integral<Source>{});
 }
 
 }

--- a/src/Common/StringTools.cpp
+++ b/src/Common/StringTools.cpp
@@ -369,4 +369,16 @@ std::string timeIntervalToString(uint64_t intervalInSeconds) {
   return ss.str();
 }
 
+bool starts_with(const std::string &str1, const std::string &str2) {
+  if (str1.length() < str2.length())
+    return false;
+  return str1.compare(0, str2.length(), str2) == 0;
+}
+
+bool ends_with(const std::string &str1, const std::string &str2) {
+  if (str1.length() < str2.length())
+    return false;
+  return str1.compare(str1.length() - str2.length(), str2.length(), str2) == 0;
+}
+
 }

--- a/src/Common/StringTools.h
+++ b/src/Common/StringTools.h
@@ -1,5 +1,5 @@
-// Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2016-2018, The Karbowanec developers
+// Copyright (c) 2012-2018, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2016-2020, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -50,6 +50,32 @@ void toHex(const std::vector<uint8_t>& data, std::string& text); // Appends hex 
 template<class T>
 std::string podToHex(const T& s) {
   return toHex(&s, sizeof(s));
+}
+
+bool starts_with(const std::string &str1, const std::string &str2);
+bool ends_with(const std::string &str1, const std::string &str2);
+
+inline bool split_string_helper(const std::string &str, size_t pos, const std::string &, std::string &head) {
+  head = str.substr(pos);
+  return true;
+}
+
+template<class... Parts>
+inline bool split_string_helper(const std::string &str,
+  size_t pos,
+  const std::string &separator,
+  std::string &head,
+  Parts &... parts) {
+  size_t pos2 = str.find(separator, pos);
+  if (pos2 == std::string::npos)
+    return false;
+  head = str.substr(pos, pos2 - pos);
+  return split_string_helper(str, pos2 + 1, separator, parts...);
+}
+
+template<class... Parts>
+inline bool split_string(const std::string &str, const std::string &separator, Parts &... parts) {
+  return split_string_helper(str, 0, separator, parts...);
 }
 
 std::string extract(std::string& text, char delimiter); // Does not throw

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -874,7 +874,7 @@ std::error_code NodeRpcProxy::doGetTransactionHashesByPaymentId(const Crypto::Ha
   COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request req = AUTO_VAL_INIT(req);
   COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response resp = AUTO_VAL_INIT(resp);
 
-  req.paymentId = paymentId;
+  req.paymentId = Common::podToHex(paymentId);
   std::error_code ec = jsonCommand("/get_transaction_hashes_by_payment_id", req, resp);
   if (ec) {
     return ec;

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -730,18 +730,6 @@ struct COMMAND_RPC_QUERY_BLOCKS_LITE {
   };
 };
 
-struct COMMAND_RPC_GEN_PAYMENT_ID {
-  typedef EMPTY_STRUCT request;
-  
-  struct response {
-	  std::string payment_id;
-
-	  void serialize(ISerializer &s) {
-		  KV_MEMBER(payment_id)
-	  }
-  };
-};
-
 //-----------------------------------------------
 struct COMMAND_RPC_CHECK_TRANSACTION_KEY {
 	struct request {

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -996,7 +996,7 @@ struct COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HASHES {
 
 struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH {
 	struct request {
-		Crypto::Hash hash;
+		std::string hash;
 
 		void serialize(ISerializer &s) {
 			KV_MEMBER(hash);

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -932,7 +932,7 @@ struct COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS {
   struct request {
     uint64_t timestampBegin;
     uint64_t timestampEnd;
-	uint32_t limit;
+    uint32_t limit;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(timestampBegin)
@@ -943,7 +943,7 @@ struct COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS {
 
   struct response {
     std::vector<Crypto::Hash> blockHashes;
-	uint32_t count;
+    uint32_t count;
     std::string status;
 
     void serialize(ISerializer &s) {
@@ -956,7 +956,7 @@ struct COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS {
 
 struct COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID {
   struct request {
-    Crypto::Hash paymentId;
+    std::string paymentId;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(paymentId)

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -265,6 +265,13 @@ struct COMMAND_RPC_START_MINING {
     }
   };
 };
+
+struct COMMAND_HTTP {
+  typedef EMPTY_STRUCT request;
+
+  typedef std::string response;
+};
+
 //-----------------------------------------------
 struct COMMAND_RPC_GET_INFO {
   typedef EMPTY_STRUCT request;

--- a/src/Rpc/HttpServer.cpp
+++ b/src/Rpc/HttpServer.cpp
@@ -97,17 +97,16 @@ void HttpServer::acceptLoop() {
     for (;;) {
       HttpRequest req;
       HttpResponse resp;
-	  resp.addHeader("Access-Control-Allow-Origin", "*");
-	  resp.addHeader("content-type", "application/json");
-	
+      resp.addHeader("Access-Control-Allow-Origin", "*");
+
       parser.receiveRequest(stream, req);
-				if (authenticate(req)) {
-					processRequest(req, resp);
-				}
-				else {
-					logger(WARNING) << "Authorization required " << addr.first.toDottedDecimal() << ":" << addr.second;
-					fillUnauthorizedResponse(resp);
-				}
+      if (authenticate(req)) {
+        processRequest(req, resp);
+      }
+      else {
+        logger(WARNING) << "Authorization required " << addr.first.toDottedDecimal() << ":" << addr.second;
+        fillUnauthorizedResponse(resp);
+      }
 
       stream << resp;
       stream.flush();

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -141,12 +141,12 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   // http handlers
   { "/", { httpMethod<COMMAND_HTTP>(&RpcServer::on_get_index), true } },
   { "/supply", { httpMethod<COMMAND_HTTP>(&RpcServer::on_get_supply), false } },
+  { "/paymentid", { httpMethod<COMMAND_HTTP>(&RpcServer::on_get_payment_id), true } },
 
   // http get json handlers
   { "/getinfo", { jsonMethod<COMMAND_RPC_GET_INFO>(&RpcServer::on_get_info), true } },
   { "/getheight", { jsonMethod<COMMAND_RPC_GET_HEIGHT>(&RpcServer::on_get_height), true } },
   { "/feeaddress", { jsonMethod<COMMAND_RPC_GET_FEE_ADDRESS>(&RpcServer::on_get_fee_address), true } },
-  { "/paymentid", { jsonMethod<COMMAND_RPC_GEN_PAYMENT_ID>(&RpcServer::on_get_payment_id), true } },
 
   // rpc post json handlers
   { "/gettransactions", { jsonMethod<COMMAND_RPC_GET_TRANSACTIONS>(&RpcServer::on_get_transactions), true } },
@@ -845,6 +845,13 @@ bool RpcServer::on_get_supply(const COMMAND_HTTP::request& req, COMMAND_HTTP::re
   return true;
 }
 
+bool RpcServer::on_get_payment_id(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res) {
+  Crypto::Hash result;
+  Random::randomBytes(32, result.data);
+  res = Common::podToHex(result);
+
+  return true;
+}
 
 //
 // JSON handlers
@@ -1173,13 +1180,6 @@ bool RpcServer::on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& r
   }
 
   res.status = CORE_RPC_STATUS_OK;
-  return true;
-}
-
-bool RpcServer::on_get_payment_id(const COMMAND_RPC_GEN_PAYMENT_ID::request& req, COMMAND_RPC_GEN_PAYMENT_ID::response& res) {
-  Crypto::Hash result;
-  Random::randomBytes(32, result.data);
-  res.payment_id = Common::podToHex(result);
   return true;
 }
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -139,6 +139,7 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
 
   // http handlers
   { "/", { httpMethod<COMMAND_HTTP>(&RpcServer::on_get_index), true } },
+  { "/supply", { httpMethod<COMMAND_HTTP>(&RpcServer::on_get_supply), false } },
 
   // http get json handlers
   { "/getinfo", { jsonMethod<COMMAND_RPC_GET_INFO>(&RpcServer::on_get_info), true } },
@@ -711,6 +712,15 @@ bool RpcServer::on_get_index(const COMMAND_HTTP::request& req, COMMAND_HTTP::res
 
   return true;
 }
+
+
+bool RpcServer::on_get_supply(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res) {
+  std::string already_generated_coins = m_core.currency().formatAmount(alreadyGeneratedCoins);
+  res = already_generated_coins;
+
+  return true;
+}
+
 
 //
 // JSON handlers

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -715,7 +715,7 @@ bool RpcServer::on_get_index(const COMMAND_HTTP::request& req, COMMAND_HTTP::res
 
 
 bool RpcServer::on_get_supply(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res) {
-  std::string already_generated_coins = m_core.currency().formatAmount(alreadyGeneratedCoins);
+  std::string already_generated_coins = m_core.currency().formatAmount(m_core.getTotalGeneratedAmount());
   res = already_generated_coins;
 
   return true;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -186,6 +186,8 @@ RpcServer::RpcServer(System::Dispatcher& dispatcher, Logging::ILogger& log, Cryp
 void RpcServer::processRequest(const HttpRequest& request, HttpResponse& response) {
   //logger(Logging::TRACE) << "RPC request came: \n" << request << std::endl;
 
+  try {
+
   auto url = request.getUrl();
 
   auto it = s_handlers.find(url);
@@ -309,6 +311,17 @@ void RpcServer::processRequest(const HttpRequest& request, HttpResponse& respons
   }
 
   it->second.handler(this, request, response);
+
+  }
+  catch (const JsonRpc::JsonRpcError& err) {
+    response.addHeader("Content-Type", "application/json");
+    response.setStatus(HttpResponse::STATUS_500);
+    response.setBody(storeToJsonValue(err).toString());
+  }
+  catch (const std::exception& e) {
+    response.setStatus(HttpResponse::STATUS_500);
+    response.setBody(e.what());
+  }
 }
 
 bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& response) {

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -277,14 +277,8 @@ void RpcServer::processRequest(const HttpRequest& request, HttpResponse& respons
           response.setBody("Core is busy");
           return;
         }
-        Crypto::Hash pid_hash;
-        if (!parse_hash256(pid_str, pid_hash)) {
-          throw JsonRpc::JsonRpcError{
-            CORE_RPC_ERROR_CODE_WRONG_PARAM,
-            "Failed to parse hex representation of payment id. Hex = " + pid_str + '.' };
-        }
         COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request req;
-        req.paymentId = pid_hash;
+        req.paymentId = pid_str;
         COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response rsp;
         bool r = on_get_transaction_hashes_by_paymentid(req, rsp);
         if (r) {
@@ -778,7 +772,14 @@ bool RpcServer::on_get_transaction_details_by_hash(const COMMAND_RPC_GET_TRANSAC
 }
 
 bool RpcServer::on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response& rsp) {
-  rsp.transactionHashes = m_core.getTransactionHashesByPaymentId(req.paymentId);
+  Crypto::Hash pid_hash;
+  if (!parse_hash256(req.paymentId, pid_hash)) {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_WRONG_PARAM,
+      "Failed to parse hex representation of payment id. Hex = " + req.paymentId + '.' };
+  }
+  
+  rsp.transactionHashes = m_core.getTransactionHashesByPaymentId(pid_hash);
 
   rsp.status = CORE_RPC_STATUS_OK;
   return true;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -213,6 +213,32 @@ void RpcServer::processRequest(const HttpRequest& request, HttpResponse& respons
           response.addHeader("Content-Type", "application/json");
           response.setStatus(HttpResponse::HTTP_STATUS::STATUS_200);
           response.setBody(storeToJson(rsp));
+        } else {
+          response.setStatus(HttpResponse::STATUS_500);
+          response.setBody("Internal error");
+        }
+        return;
+
+      } else if (Common::starts_with(url, block_hash_method)) {
+
+        std::string hash_str = url.substr(block_hash_method.size());
+        auto it = s_handlers.find("/get_block_details_by_hash");
+        if (!it->second.allowBusyCore && !isCoreReady()) {
+          response.setStatus(HttpResponse::STATUS_500);
+          response.setBody("Core is busy");
+          return;
+        }
+        COMMAND_RPC_GET_BLOCK_DETAILS_BY_HASH::request req;
+        req.hash = hash_str;
+        COMMAND_RPC_GET_BLOCK_DETAILS_BY_HASH::response rsp;
+        bool r = on_get_block_details_by_hash(req, rsp);
+        if (r) {
+          response.addHeader("Content-Type", "application/json");
+          response.setStatus(HttpResponse::HTTP_STATUS::STATUS_200);
+          response.setBody(storeToJson(rsp));
+        } else {
+          response.setStatus(HttpResponse::STATUS_500);
+          response.setBody("Internal error");
         }
         return;
 
@@ -221,6 +247,7 @@ void RpcServer::processRequest(const HttpRequest& request, HttpResponse& respons
       } else if (Common::starts_with(url, payment_id_method)) {
 
       }
+      response.setStatus(HttpResponse::STATUS_404);
       return;
     }
     else {

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -94,6 +94,36 @@ RpcServer::HandlerFunction jsonMethod(bool (RpcServer::*handler)(typename Comman
   };
 }
 
+template <typename Command>
+RpcServer::HandlerFunction httpMethod(bool (RpcServer::*handler)(typename Command::request const&, typename Command::response&)) {
+  return [handler](RpcServer* obj, const HttpRequest& request, HttpResponse& response) {
+
+    boost::value_initialized<typename Command::request> req;
+    boost::value_initialized<typename Command::response> res;
+
+    if (!loadFromJson(static_cast<typename Command::request&>(req), request.getBody())) {
+      return false;
+    }
+
+    bool result = (obj->*handler)(req, res);
+
+    std::string cors_domain = obj->getCorsDomain();
+    if (!cors_domain.empty()) {
+      response.addHeader("Access-Control-Allow-Origin", cors_domain);
+      response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+      response.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+    }
+    response.addHeader("Content-Type", "text/html; charset=UTF-8");
+    response.addHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+    response.addHeader("Expires", "0");
+    response.setStatus(HttpResponse::HTTP_STATUS::STATUS_200);
+
+    response.setBody(res);
+
+    return result;
+  };
+}
+
 }
 
 std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction>> RpcServer::s_handlers = {
@@ -106,6 +136,9 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   { "/getrandom_outs.bin", { binMethod<COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS>(&RpcServer::on_get_random_outs), false } },
   { "/get_pool_changes.bin", { binMethod<COMMAND_RPC_GET_POOL_CHANGES>(&RpcServer::on_get_pool_changes), false } },
   { "/get_pool_changes_lite.bin", { binMethod<COMMAND_RPC_GET_POOL_CHANGES_LITE>(&RpcServer::on_get_pool_changes_lite), false } },
+
+  // http handlers
+  { "/", { httpMethod<COMMAND_HTTP>(&RpcServer::on_get_index), true } },
 
   // http get json handlers
   { "/getinfo", { jsonMethod<COMMAND_RPC_GET_INFO>(&RpcServer::on_get_info), true } },
@@ -628,6 +661,58 @@ bool RpcServer::on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRA
 }
 
 //
+// HTTP handlers
+//
+
+bool RpcServer::on_get_index(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res) {
+  const std::string index_start =
+    R"(<html><head><meta http-equiv='refresh' content='60'/></head><body><p><svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" version="1.1" style="vertical-align:middle; padding-right: 10px; shape-rendering:geometricPrecision; text-rendering:geometricPrecision; image-rendering:optimizeQuality; fill-rule:evenodd; clip-rule:evenodd" viewBox="0 0 2500000 2500000" xmlns:xlink="http://www.w3.org/1999/xlink" width="64px" height="64px">
+<g>
+<circle fill="#0AACFC" cx="1250000" cy="1250000" r="1214062" />
+<path fill="#FFED00" d="M1251219 1162750c18009,-3203 34019,-10006 48025,-20412 14009,-10407 27215,-28016 39622,-52029l275750 -538290c10803,-18010 24012,-32419 39218,-43625 15210,-10806 33219,-16410 53232,-16410l174893 0 -343384 633144c-15209,26016 -32419,47228 -51628,63635 -19613,16409 -41225,28815 -64838,37221 36822,9604 67638,25213 92854,47225 24812,21610 48425,52025 70437,91247l330578 668363 -192503 0c-38822,0 -70041,-21213 -93653,-63235l-270947 -566303c-14006,-25215 -29216,-43225 -45622,-54034 -16409,-10803 -37222,-17206 -62034,-18809l0 287359 -151281 0 0 -288559 -111263 0 0 703581 -213716 0 0 -1540835 213716 0 0 673166 111263 0 0 -332981 151281 0 0 330581z"/>
+</g></svg></svg></td><td>)" "karbowanec" R"(d &bull; version 
+)";
+  const std::string index_finish = " </p></body></html>";
+  const std::time_t uptime = std::time(nullptr) - m_core.getStartTime();
+  const std::string uptime_str = std::to_string((unsigned int)floor(uptime / 60.0 / 60.0 / 24.0)) + "d " + std::to_string((unsigned int)floor(fmod((uptime / 60.0 / 60.0), 24.0))) + "h "
+    + std::to_string((unsigned int)floor(fmod((uptime / 60.0), 60.0))) + "m " + std::to_string((unsigned int)fmod(uptime, 60.0)) + "s";
+  uint32_t top_block_index = m_core.getCurrentBlockchainHeight() - 1;
+  uint32_t top_known_block_index = std::max(static_cast<uint32_t>(1), m_protocolQuery.getObservedHeight()) - 1;
+  size_t outConn = m_p2p.get_outgoing_connections_count();
+  size_t incConn = m_p2p.get_connections_count() - outConn;
+  Crypto::Hash last_block_hash = m_core.getBlockIdByHeight(top_block_index);
+  size_t white_peerlist_size = m_p2p.getPeerlistManager().get_white_peers_count();
+  size_t grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
+  size_t alt_blocks_count = m_core.getAlternativeBlocksCount();
+  size_t total_tx_count = m_core.getBlockchainTotalTransactions() - top_block_index + 1;
+  size_t tx_pool_count = m_core.getPoolTransactionsCount();
+
+  const std::string body = index_start + PROJECT_VERSION_LONG + " &bull; " + (m_core.currency().isTestnet() ? "testnet" : "mainnet") +
+    "<ul>" +
+      "<li>" + "Synchronization status: " + std::to_string(top_block_index) + "/" + std::to_string(top_known_block_index) +
+      "<li>" + "Last block hash: " + Common::podToHex(last_block_hash) + "</li>" +
+      "<li>" + "Difficulty: " + std::to_string(m_core.getNextBlockDifficulty()) + "</li>" +
+      "<li>" + "Alt. blocks: " + std::to_string(alt_blocks_count) + "</li>" +
+      "<li>" + "Total transactions in network: " + std::to_string(total_tx_count) + "</li>" +
+      "<li>" + "Transactions in pool: " + std::to_string(tx_pool_count) + "</li>" +
+      "<li>" + "Connections:" +
+        "<ul>" +
+          "<li>" + "RPC: " + std::to_string(get_connections_count()) + "</li>" +
+          "<li>" + "OUT: " + std::to_string(outConn) + "</li>" +
+          "<li>" + "INC: " + std::to_string(incConn) + "</li>" +
+        "</ul>" +
+      "</li>" +
+      "<li>" + "Peers: " + std::to_string(white_peerlist_size) + " white, " + std::to_string(grey_peerlist_size) + " grey" + "</li>" +
+      "<li>" + "Uptime: " + uptime_str + "</li>" +
+    "</ul>" +
+    index_finish;
+
+  res = body;
+
+  return true;
+}
+
+//
 // JSON handlers
 //
 
@@ -655,17 +740,7 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   // that large uint64_t number is unsafe in JavaScript environment and therefore as a JSON value so we display it as a formatted string
   res.already_generated_coins = m_core.currency().formatAmount(alreadyGeneratedCoins);
   res.block_major_version = m_core.getCurrentBlockMajorVersion();
-  std::vector<size_t> blocksSizes;
-  if (!m_core.getBackwardBlocksSizes(res.height - 1, blocksSizes, parameters::CRYPTONOTE_REWARD_BLOCKS_WINDOW)) {
-    return false;
-  }
-  uint64_t sizeMedian = Common::medianValue(blocksSizes);
-  uint64_t nextReward = 0;
-  int64_t emissionChange = 0;
-  if (!m_core.getBlockReward(res.block_major_version, sizeMedian, 0, alreadyGeneratedCoins, 0, nextReward, emissionChange)) {
-    throw JsonRpc::JsonRpcError{
-      CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: can't get already generated coins for prev. block." };
-  }
+  uint64_t nextReward = m_core.currency().calculateReward(alreadyGeneratedCoins);
   res.next_reward = nextReward;
   
   if (!m_core.getBlockCumulativeDifficulty(res.height - 1, res.cumulative_difficulty)) {

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -78,6 +78,7 @@ private:
 
   // http handlers
   bool on_get_index(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res);
+  bool on_get_supply(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res);
 
   // json handlers
   bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res);

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -76,6 +76,9 @@ private:
   bool on_get_pool_changes(const COMMAND_RPC_GET_POOL_CHANGES::request& req, COMMAND_RPC_GET_POOL_CHANGES::response& rsp);
   bool on_get_pool_changes_lite(const COMMAND_RPC_GET_POOL_CHANGES_LITE::request& req, COMMAND_RPC_GET_POOL_CHANGES_LITE::response& rsp);
 
+  // http handlers
+  bool on_get_index(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res);
+
   // json handlers
   bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res);
   bool on_get_height(const COMMAND_RPC_GET_HEIGHT::request& req, COMMAND_RPC_GET_HEIGHT::response& res);

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -79,6 +79,7 @@ private:
   // http handlers
   bool on_get_index(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res);
   bool on_get_supply(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res);
+  bool on_get_payment_id(const COMMAND_HTTP::request& req, COMMAND_HTTP::response& res);
 
   // json handlers
   bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res);
@@ -90,7 +91,6 @@ private:
   bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
   bool on_get_fee_address(const COMMAND_RPC_GET_FEE_ADDRESS::request& req, COMMAND_RPC_GET_FEE_ADDRESS::response& res);
   bool on_get_peer_list(const COMMAND_RPC_GET_PEER_LIST::request& req, COMMAND_RPC_GET_PEER_LIST::response& res);
-  bool on_get_payment_id(const COMMAND_RPC_GEN_PAYMENT_ID::request& req, COMMAND_RPC_GEN_PAYMENT_ID::response& res);
   bool on_get_connections(const COMMAND_RPC_GET_CONNECTIONS::request& req, COMMAND_RPC_GET_CONNECTIONS::response& res);
   
   bool on_get_blocks_details_by_heights(const COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HEIGHTS::request& req, COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HEIGHTS::response& rsp);


### PR DESCRIPTION
* Exposes these RESTful-like API endpoints for GET requests:

  * `/api/block/height/[height]` - returns block info in JSON by height
  * `/api/block/hash/[hash]` - returns block info in JSON by hash
  * `/api/transaction/[hash]` - returns transaction info in JSON by hash
  * `/api/payment_id/[hash]` - returns the list of transaction hashes by payment id in JSON

  which is convenient to get block or tx info in browser without the need of making a POST request.

* Adds nice HTML output to `/` path with basic stats
* Adds plain HTML `/supply` endpoint that returns a string with total coins in circulation
* Moves `/paimentid` endpoint to the plain HTML output of randomly generated payment id instead of JSON

E.g. complete URL looks like `http://127.0.0.1:32348/api/block/height/12345`
