### PR TITLE
Sign/verify message overhaul

### DIFF
--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -191,6 +191,9 @@ public:
 
   virtual std::string getReserveProof(const uint64_t &reserve, const std::string& address, const std::string &message) = 0;
 
+  virtual std::string signMessage(const std::string &message, const std::string& address) = 0;
+  virtual bool verifyMessage(const std::string &message, const std::string& address, const std::string &signature) = 0;
+
   virtual size_t transfer(const TransactionParameters& sendingTransaction, Crypto::SecretKey &txSecretKey) = 0;
 
   virtual size_t makeTransaction(const TransactionParameters& sendingTransaction) = 0;

--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -152,8 +152,8 @@ public:
   virtual std::vector<TransactionOutputInformation> getTransactionInputs(const Crypto::Hash& transactionHash, uint32_t flags) const = 0;
   virtual bool isFusionTransaction(const WalletLegacyTransaction& walletTx) const = 0;
 
-  virtual std::string sign_message(const std::string &data) = 0;
-  virtual bool verify_message(const std::string &data, const CryptoNote::AccountPublicAddress &address, const std::string &signature) = 0;
+  virtual std::string sign_message(const std::string &message) = 0;
+  virtual bool verify_message(const std::string &message, const CryptoNote::AccountPublicAddress &address, const std::string &signature) = 0;
 
   virtual bool isTrackingWallet() = 0;
 };

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -36,6 +36,7 @@ const size_t   CRYPTONOTE_MAX_TX_SIZE                        = 1000000000;
 const uint64_t CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX       = 111; // addresses start with "K"
 const uint64_t CRYPTONOTE_TX_PROOF_BASE58_PREFIX             = 3576968; // (0x369488), starts with "Proof..."
 const uint64_t CRYPTONOTE_RESERVE_PROOF_BASE58_PREFIX        = 44907175188; // (0xa74ad1d14), starts with "RsrvPrf..."
+const uint64_t CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX       = 176103705; // (0xa7f2119), starts with "SigV1..."
 const size_t   CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW          = 10;
 const size_t   CRYPTONOTE_TX_SPENDABLE_AGE                   = 6;
 const uint64_t CRYPTONOTE_BLOCK_FUTURE_TIME_LIMIT            = DIFFICULTY_TARGET * 7;

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -720,4 +720,36 @@ bool getReserveProof(const std::vector<TransactionOutputInformation>& selectedTr
   return true;
 }
 
+std::string signMessage(const std::string &data, const CryptoNote::AccountKeys &keys) {
+  Crypto::Hash hash;
+  Crypto::cn_fast_hash(data.data(), data.size(), hash);
+  
+  Crypto::Signature signature;
+  Crypto::generate_signature(hash, keys.address.spendPublicKey, keys.spendSecretKey, signature);
+  return Tools::Base58::encode_addr(CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX, std::string((const char *)&signature, sizeof(signature)));
+}
+
+bool verifyMessage(const std::string &data, const CryptoNote::AccountPublicAddress &address, const std::string &signature, Logging::ILogger& log) {
+  LoggerRef logger(log, "verify_message");
+
+  std::string decoded;
+  uint64_t prefix;
+  if (!Tools::Base58::decode_addr(signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
+    logger(Logging::ERROR) << "Signature decoding error";
+    return false;
+  }
+
+  Crypto::Signature s;
+  if (sizeof(s) != decoded.size()) {
+    logger(Logging::ERROR) << "Signature size wrong";
+    return false;
+  }
+
+  Crypto::Hash hash;
+  Crypto::cn_fast_hash(data.data(), data.size(), hash);
+
+  memcpy(&s, decoded.data(), sizeof(s));
+  return Crypto::check_signature(hash, address.spendPublicKey, s);
+}
+
 }

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -62,6 +62,11 @@ bool constructTransaction(
   const std::vector<TransactionDestinationEntry>& destinations,
   std::vector<uint8_t> extra, Transaction& transaction, uint64_t unlock_time, Crypto::SecretKey &tx_key, Logging::ILogger& log);
 
+bool getTransactionProof(const Crypto::Hash& transactionHash, const CryptoNote::AccountPublicAddress& destinationAddress, const Crypto::SecretKey& transactionKey, std::string& transactionProof, Logging::ILogger& log);
+bool getReserveProof(const std::vector<TransactionOutputInformation>& selectedTransfers, const CryptoNote::AccountKeys& accountKeys, const uint64_t& amount, const std::string& message, std::string& reserveProof, Logging::ILogger& log);
+
+std::string signMessage(const std::string &data, const CryptoNote::AccountKeys &keys);
+bool verifyMessage(const std::string &data, const CryptoNote::AccountPublicAddress &address, const std::string &signature, Logging::ILogger& log);
 
 bool is_out_to_acc(const AccountKeys& acc, const KeyOutput& out_key, const Crypto::PublicKey& tx_pub_key, size_t keyIndex);
 bool is_out_to_acc(const AccountKeys& acc, const KeyOutput& out_key, const Crypto::KeyDerivation& derivation, size_t keyIndex);
@@ -129,8 +134,4 @@ void get_tx_tree_hash(const std::vector<Crypto::Hash>& tx_hashes, Crypto::Hash& 
 Crypto::Hash get_tx_tree_hash(const std::vector<Crypto::Hash>& tx_hashes);
 Crypto::Hash get_tx_tree_hash(const Block& b);
 bool is_valid_decomposed_amount(uint64_t amount);
-
-bool getTransactionProof(const Crypto::Hash& transactionHash, const CryptoNote::AccountPublicAddress& destinationAddress, const Crypto::SecretKey& transactionKey, std::string& transactionProof, Logging::ILogger& log);
-bool getReserveProof(const std::vector<TransactionOutputInformation>& selectedTransfers, const CryptoNote::AccountKeys& accountKeys, const uint64_t& amount, const std::string& message, std::string& reserveProof, Logging::ILogger& log);
-
 }

--- a/src/GreenWallet/CommandDispatcher.cpp
+++ b/src/GreenWallet/CommandDispatcher.cpp
@@ -117,6 +117,14 @@ bool handleCommand(const std::string command,
     {
         txProof(walletInfo->wallet);
     }
+    else if (command == "sign_message")
+    {
+      signMessage(walletInfo, walletInfo->viewWallet);
+    }
+    else if (command == "verify_message")
+    {
+      verifyMessage(walletInfo->wallet);
+    }
     /* This should never happen */
     else
     {

--- a/src/GreenWallet/CommandImplementations.cpp
+++ b/src/GreenWallet/CommandImplementations.cpp
@@ -742,8 +742,8 @@ void txProof(CryptoNote::WalletGreen &wallet)
     {
         std::cout << InformationMsg("Enter destination address: ");
 
-		std::string addrStr;
-		uint64_t prefix;
+        std::string addrStr;
+        uint64_t prefix;
 
         std::getline(std::cin, addrStr);
         boost::algorithm::trim(addrStr);
@@ -916,6 +916,146 @@ void reserveProof(std::shared_ptr<WalletInfo> walletInfo, bool viewWallet)
     }
     catch (const std::exception &e) {
         std::cout << WarningMsg("Failed to get reserve proof: ")
+                  << WarningMsg(e.what())
+                  << std::endl;
+    }
+}
+
+void signMessage(std::shared_ptr<WalletInfo> walletInfo, bool viewWallet)
+{
+    if (viewWallet)
+    {
+        std::cout << WarningMsg("This is tracking wallet. ")
+                  << WarningMsg("The message can be signed ")
+                  << WarningMsg("only by a full wallet.")
+                  << std::endl;
+        return;
+    }
+
+    std::string message;
+
+    while (true)
+    {
+        std::cout << InformationMsg("Enter message to sign: ");
+
+        std::getline(std::cin, message);
+        boost::algorithm::trim(message);
+
+        if (!message.empty())
+        {
+          break;
+        }
+
+        if (std::cin.fail() || std::cin.eof()) {
+            std::cin.clear();
+            break;
+        }
+    }
+
+    try
+    {
+        std::string walletAddress = walletInfo->walletAddress;
+
+        std::string signature = walletInfo->wallet.signMessage(message, walletAddress);
+
+        std::cout << SuccessMsg("Signature: ") 
+                  << InformationMsg(signature)
+                  << std::endl;
+    }
+    catch (const std::exception &e) {
+        std::cout << WarningMsg("Failed to sign message: ")
+                  << WarningMsg(e.what())
+                  << std::endl;
+    }
+}
+
+void verifyMessage(CryptoNote::WalletGreen &wallet)
+{
+    std::string addrStr;
+
+    while (true)
+    {
+        std::cout << InformationMsg("Enter address: ");
+
+        CryptoNote::AccountPublicAddress address;
+        
+        uint64_t prefix;
+
+        std::getline(std::cin, addrStr);
+        boost::algorithm::trim(addrStr);
+
+        if (!CryptoNote::parseAccountAddressString(prefix, address, addrStr))
+        {
+            std::cout << WarningMsg("Failed to parse address") << std::endl;
+        }
+        else
+        {
+            break;
+        }
+
+        if (std::cin.fail() || std::cin.eof()) {
+            std::cin.clear();
+            break;
+        }
+    }
+
+    std::string message;
+
+    while (true)
+    {
+        std::cout << InformationMsg("Enter message: ");
+
+        std::getline(std::cin, message);
+        boost::algorithm::trim(message);
+
+        if (!message.empty())
+        {
+            break;
+        }
+
+        if (std::cin.fail() || std::cin.eof()) {
+            std::cin.clear();
+            break;
+        }
+    }
+
+    std::string signature;
+
+    while (true)
+    {
+        std::cout << InformationMsg("Enter signature: ");
+
+        std::getline(std::cin, signature);
+        boost::algorithm::trim(signature);       
+
+        if (!signature.empty())
+        {
+            break;
+        }
+
+        if (std::cin.fail() || std::cin.eof()) {
+            std::cin.clear();
+            break;
+        }
+    }
+
+    try
+    {
+        bool r = wallet.verifyMessage(message, addrStr, signature);
+
+        if (r)
+        {
+            std::cout << SuccessMsg("Signature is valid") 
+                      << std::endl;
+        }
+        else
+        {
+            std::cout << WarningMsg("Signature is invalid")
+                      << std::endl;
+        }
+    }
+    catch (const std::exception &e) {
+        std::cout << WarningMsg("Failed to verify message: ")
                   << WarningMsg(e.what())
                   << std::endl;
     }

--- a/src/GreenWallet/CommandImplementations.h
+++ b/src/GreenWallet/CommandImplementations.h
@@ -65,3 +65,7 @@ void reserveProof(std::shared_ptr<WalletInfo> walletInfo, bool viewWallet);
 void txSecretKey(CryptoNote::WalletGreen &wallet);
 
 void txProof(CryptoNote::WalletGreen &wallet);
+
+void signMessage(std::shared_ptr<WalletInfo> walletInfo, bool viewWallet);
+
+void verifyMessage(CryptoNote::WalletGreen &wallet);

--- a/src/GreenWallet/Commands.cpp
+++ b/src/GreenWallet/Commands.cpp
@@ -61,10 +61,12 @@ std::vector<AdvancedCommand> allCommands()
 		AdvancedCommand("save", "Save your wallet state", true, true),
 		AdvancedCommand("save_csv", "Save all wallet transactions to a CSV file", true, true),
 		AdvancedCommand("send_all", "Send all your balance to someone", false, true),
+		AdvancedCommand("sign_message", "Sign message with your wallet keys", false, true),
 		AdvancedCommand("status", "Display sync status and network hashrate", true, true),
 		AdvancedCommand("tx_key", "Display transaction secret key if it's stored in wallet cache", false, true),
-        AdvancedCommand("tx_proof", "Display proof of payment to specified address", false, true),
-    };
+		AdvancedCommand("tx_proof", "Display proof of payment to specified address", false, true),
+		AdvancedCommand("verify_message", "Verify signed message", true, true),
+	};
 }
 
 std::vector<AdvancedCommand> basicCommands()

--- a/src/GreenWallet/Sync.cpp
+++ b/src/GreenWallet/Sync.cpp
@@ -124,7 +124,7 @@ void syncWallet(CryptoNote::INode &node,
         remoteHeight = node.getLastKnownBlockHeight();
         std::cout << SuccessMsg(std::to_string(walletHeight))
                   << " of " << InformationMsg(std::to_string(localHeight))
-                  << "\r" << std::flush;
+                  << "                                       \r" << std::flush;
 
         const uint32_t tmpWalletHeight = walletInfo->wallet.getBlockCount();
 

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -81,7 +81,7 @@ void ValidateAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
 }
 
 void ValidateAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
-  serializer(isvalid, "isvalid");
+  serializer(isValid, "isValid");
   serializer(address, "address");
   serializer(spendPublicKey, "spendPublicKey");
   serializer(viewPublicKey, "viewPublicKey");
@@ -317,6 +317,29 @@ void WalletRpcOrder::serialize(CryptoNote::ISerializer& serializer) {
   if (!r) {
     throw RequestSerializationError();
   }
+}
+
+void SignMessage::Request::serialize(CryptoNote::ISerializer& serializer) {
+  serializer(address, "address");
+
+  if (!serializer(message, "message")) {
+    throw RequestSerializationError();
+  }
+}
+
+void SignMessage::Response::serialize(CryptoNote::ISerializer& serializer) {
+  serializer(address, "address");
+  serializer(signature, "signature");
+}
+
+void VerifyMessage::Request::serialize(CryptoNote::ISerializer& serializer) {
+  if (!serializer(address, "address") || !serializer(message, "message") || !serializer(signature, "signature")) {
+    throw RequestSerializationError();
+  }
+}
+
+void VerifyMessage::Response::serialize(CryptoNote::ISerializer& serializer) {
+  serializer(isValid, "isValid");
 }
 
 void SendTransaction::Request::serialize(CryptoNote::ISerializer& serializer) {

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -122,7 +122,7 @@ struct ValidateAddress {
 	};
 
 	struct Response {
-		bool isvalid;
+		bool isValid;
 		std::string address;
 		std::string spendPublicKey;
 		std::string viewPublicKey;
@@ -381,14 +381,46 @@ struct GetTransactionProof {
 struct GetReserveProof {
   struct Request {
     std::string address;
-	std::string message;
-	uint64_t amount = 0;
+    std::string message;
+    uint64_t amount = 0;
 
     void serialize(CryptoNote::ISerializer& serializer);
   };
 
   struct Response {
     std::string reserveProof;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+};
+
+struct SignMessage {
+  struct Request {
+    std::string address;
+    std::string message;
+  
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+
+  struct Response {
+    std::string address;
+    std::string signature;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+};
+
+struct VerifyMessage {
+  struct Request {
+    std::string address;
+    std::string message;
+    std::string signature;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+
+  struct Response {
+    bool isValid;
 
     void serialize(CryptoNote::ISerializer& serializer);
   };

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -66,6 +66,9 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
   handlers.emplace("estimateFusion", jsonHandler<EstimateFusion::Request, EstimateFusion::Response>(std::bind(&PaymentServiceJsonRpcServer::handleEstimateFusion, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("validateAddress", jsonHandler<ValidateAddress::Request, ValidateAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleValidateAddress, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getReserveProof", jsonHandler<GetReserveProof::Request, GetReserveProof::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetReserveProof, this, std::placeholders::_1, std::placeholders::_2)));
+  handlers.emplace("signMessage", jsonHandler<SignMessage::Request, SignMessage::Response>(std::bind(&PaymentServiceJsonRpcServer::handleSignMessage, this, std::placeholders::_1, std::placeholders::_2)));
+  handlers.emplace("verifyMessage", jsonHandler<VerifyMessage::Request, VerifyMessage::Response>(std::bind(&PaymentServiceJsonRpcServer::handleVerifyMessage, this, std::placeholders::_1, std::placeholders::_2)));
+
 }
 
 void PaymentServiceJsonRpcServer::processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) {
@@ -213,6 +216,22 @@ std::error_code PaymentServiceJsonRpcServer::handleGetReserveProof(const GetRese
   return service.getReserveProof(response.reserveProof, request.address, request.message, request.amount);
 }
 
+std::error_code PaymentServiceJsonRpcServer::handleSignMessage(const SignMessage::Request& request, SignMessage::Response& response) {
+  if (request.address.empty()) {
+    std::vector<std::string> addresses;
+    service.getAddresses(addresses);
+    response.address = addresses[0];
+  } else {
+    response.address = request.address;
+  }
+  
+  return service.signMessage(request.message, request.address, response.signature);
+}
+
+std::error_code PaymentServiceJsonRpcServer::handleVerifyMessage(const VerifyMessage::Request& request, VerifyMessage::Response& response) {
+  return service.verifyMessage(request.message, request.signature, request.address, response.isValid);
+}
+
 std::error_code PaymentServiceJsonRpcServer::handleSendTransaction(const SendTransaction::Request& request, SendTransaction::Response& response) {
   return service.sendTransaction(request, response.transactionHash, response.transactionSecretKey);
 }
@@ -247,7 +266,7 @@ std::error_code PaymentServiceJsonRpcServer::handleGetStatus(const GetStatus::Re
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleValidateAddress(const ValidateAddress::Request& request, ValidateAddress::Response& response) {
-  return service.validateAddress(request.address, response.isvalid, response.address, response.spendPublicKey, response.viewPublicKey);
+  return service.validateAddress(request.address, response.isValid, response.address, response.spendPublicKey, response.viewPublicKey);
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleGetAddresses(const GetAddresses::Request& request, GetAddresses::Response& response) {

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.h
@@ -101,7 +101,8 @@ private:
   std::error_code handleGetAddressesCount(const GetAddressesCount::Request& request, GetAddressesCount::Response& response);
   std::error_code handleValidateAddress(const ValidateAddress::Request& request, ValidateAddress::Response& response);
   std::error_code handleGetReserveProof(const GetReserveProof::Request& request, GetReserveProof::Response& response);
-
+  std::error_code handleSignMessage(const SignMessage::Request& request, SignMessage::Response& response);
+  std::error_code handleVerifyMessage(const VerifyMessage::Request& request, VerifyMessage::Response& response);
   std::error_code handleSendFusionTransaction(const SendFusionTransaction::Request& request, SendFusionTransaction::Response& response);
   std::error_code handleEstimateFusion(const EstimateFusion::Request& request, EstimateFusion::Response& response);
 };

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -109,8 +109,10 @@ public:
   std::error_code sendFusionTransaction(uint64_t threshold, uint32_t anonymity, const std::vector<std::string>& addresses,
     const std::string& destinationAddress, std::string& transactionHash);
   std::error_code estimateFusion(uint64_t threshold, const std::vector<std::string>& addresses, uint32_t& fusionReadyCount, uint32_t& totalOutputCount);
-  std::error_code validateAddress(const std::string& address, bool& isvalid, std::string& _address, std::string& spendPublicKey, std::string& viewPublicKey);
+  std::error_code validateAddress(const std::string& address, bool& isValid, std::string& _address, std::string& spendPublicKey, std::string& viewPublicKey);
   std::error_code getReserveProof(std::string& reserveProof, const std::string& address, const std::string& message, const uint64_t& amount = 0);
+  std::error_code signMessage(const std::string& message, const std::string& address, std::string& signature);
+  std::error_code verifyMessage(const std::string& message, const std::string& signature, const std::string& address, bool& isValid);
 
 private:
   void refresh();

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -339,21 +339,21 @@ struct COMMAND_RPC_STOP_DAEMON {
 
 //-----------------------------------------------
 struct COMMAND_RPC_GET_PEER_LIST {
-	typedef EMPTY_STRUCT request;
+  typedef EMPTY_STRUCT request;
 
-	struct response {
-		std::vector<std::string> anchor_peers;
-		std::vector<std::string> white_peers;
-		std::vector<std::string> gray_peers;
-		std::string status;
+  struct response {
+    std::vector<std::string> anchor_peers;
+    std::vector<std::string> white_peers;
+    std::vector<std::string> gray_peers;
+    std::string status;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(anchor_peers)
-			KV_MEMBER(white_peers)
-			KV_MEMBER(gray_peers)
-			KV_MEMBER(status)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(anchor_peers)
+      KV_MEMBER(white_peers)
+      KV_MEMBER(gray_peers)
+      KV_MEMBER(status)
+    }
+  };
 };
 
 //-----------------------------------------------
@@ -641,23 +641,23 @@ struct COMMAND_RPC_GET_BLOCKS_LIST {
 
 //-----------------------------------------------
 struct COMMAND_RPC_GET_TRANSACTIONS_BY_PAYMENT_ID {
-	struct request {
-		std::string payment_id;
+  struct request {
+    std::string payment_id;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(payment_id)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(payment_id)
+    }
+  };
 
-	struct response {
-		std::vector<transaction_short_response> transactions;
-		std::string status;
+  struct response {
+    std::vector<transaction_short_response> transactions;
+    std::string status;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(transactions)
-				KV_MEMBER(status)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(transactions)
+      KV_MEMBER(status)
+    }
+  };
 };
 
 struct COMMAND_RPC_GET_TRANSACTIONS_POOL {
@@ -732,29 +732,29 @@ struct COMMAND_RPC_QUERY_BLOCKS_LITE {
 
 //-----------------------------------------------
 struct COMMAND_RPC_CHECK_TRANSACTION_KEY {
-	struct request {
-		std::string transaction_id;
-		std::string transaction_key;
-		std::string address;
+  struct request {
+    std::string transaction_id;
+    std::string transaction_key;
+    std::string address;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(transaction_id)
-			KV_MEMBER(transaction_key)
-			KV_MEMBER(address)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(transaction_id)
+      KV_MEMBER(transaction_key)
+      KV_MEMBER(address)
+    }
+  };
 
-	struct response {
-		uint64_t amount;
-		std::vector<TransactionOutput> outputs;
-		std::string status;
+  struct response {
+    uint64_t amount;
+    std::vector<TransactionOutput> outputs;
+    std::string status;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(amount)
-			KV_MEMBER(outputs)
-			KV_MEMBER(status)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(amount)
+      KV_MEMBER(outputs)
+      KV_MEMBER(status)
+    }
+  };
 };
 
 //-----------------------------------------------
@@ -813,27 +813,27 @@ struct COMMAND_RPC_VALIDATE_ADDRESS {
 };
 
 struct COMMAND_RPC_VERIFY_MESSAGE {
-	struct request {
-		std::string message;
-		std::string address;
-		std::string signature;
+  struct request {
+    std::string message;
+    std::string address;
+    std::string signature;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(message)
-			KV_MEMBER(address)
-			KV_MEMBER(signature)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(message)
+      KV_MEMBER(address)
+      KV_MEMBER(signature)
+    }
+  };
 
-	struct response {
-		bool sig_valid;
-		std::string status;
+  struct response {
+    bool sig_valid;
+    std::string status;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(sig_valid)
-			KV_MEMBER(status)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(sig_valid)
+      KV_MEMBER(status)
+    }
+  };
 };
 
 struct COMMAND_RPC_GET_BLOCKS_DETAILS_BY_HEIGHTS {
@@ -983,44 +983,44 @@ struct COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HASHES {
 };
 
 struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH {
-	struct request {
-		std::string hash;
+  struct request {
+    std::string hash;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(hash);
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(hash);
+    }
+  };
 
-	struct response {
-		TransactionDetails transaction;
-		std::string status;
+  struct response {
+    TransactionDetails transaction;
+    std::string status;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(status)
-			KV_MEMBER(transaction)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(status)
+      KV_MEMBER(transaction)
+    }
+  };
 };
 
 //-----------------------------------------------
 struct reserve_proof_entry
 {
-	Crypto::Hash transaction_id;
-	uint64_t index_in_transaction;
-	Crypto::PublicKey shared_secret;
-	Crypto::KeyImage key_image;
-	Crypto::Signature shared_secret_sig;
-	Crypto::Signature key_image_sig;
+  Crypto::Hash transaction_id;
+  uint64_t index_in_transaction;
+  Crypto::PublicKey shared_secret;
+  Crypto::KeyImage key_image;
+  Crypto::Signature shared_secret_sig;
+  Crypto::Signature key_image_sig;
 
-	void serialize(ISerializer& s)
-	{
-		KV_MEMBER(transaction_id)
-		KV_MEMBER(index_in_transaction)
-		KV_MEMBER(shared_secret)
-		KV_MEMBER(key_image)
-		KV_MEMBER(shared_secret_sig)
-		KV_MEMBER(key_image_sig)
-	}
+  void serialize(ISerializer& s)
+  {
+    KV_MEMBER(transaction_id)
+    KV_MEMBER(index_in_transaction)
+    KV_MEMBER(shared_secret)
+    KV_MEMBER(key_image)
+    KV_MEMBER(shared_secret_sig)
+    KV_MEMBER(key_image_sig)
+  }
 };
 
 struct reserve_proof {
@@ -1034,63 +1034,63 @@ struct reserve_proof {
 };
 
 struct COMMAND_RPC_CHECK_TRANSACTION_PROOF {
-    struct request {
-        std::string transaction_id;
-        std::string destination_address;
-        std::string signature;
+  struct request {
+    std::string transaction_id;
+    std::string destination_address;
+    std::string signature;
 
-        void serialize(ISerializer &s) {
-            KV_MEMBER(transaction_id)
-            KV_MEMBER(destination_address)
-            KV_MEMBER(signature)
-        }
-    };
+    void serialize(ISerializer &s) {
+      KV_MEMBER(transaction_id)
+      KV_MEMBER(destination_address)
+      KV_MEMBER(signature)
+    }
+  };
 
-    struct response {
-        bool signature_valid;
-        uint64_t received_amount;
-		std::vector<TransactionOutput> outputs;
-		uint32_t confirmations = 0;
-        std::string status;
+  struct response {
+    bool signature_valid;
+    uint64_t received_amount;
+    std::vector<TransactionOutput> outputs;
+    uint32_t confirmations = 0;
+    std::string status;
 
-        void serialize(ISerializer &s) {
-            KV_MEMBER(signature_valid)
-            KV_MEMBER(received_amount)
-            KV_MEMBER(outputs)
-            KV_MEMBER(confirmations)
-            KV_MEMBER(status)
-        }
-    };
+    void serialize(ISerializer &s) {
+      KV_MEMBER(signature_valid)
+      KV_MEMBER(received_amount)
+      KV_MEMBER(outputs)
+      KV_MEMBER(confirmations)
+      KV_MEMBER(status)
+    }
+  };
 };
 
 struct COMMAND_RPC_CHECK_RESERVE_PROOF {
-	struct request {
-		std::string address;
-		std::string message;
-		std::string signature;
+  struct request {
+    std::string address;
+    std::string message;
+    std::string signature;
     uint32_t height = 0;
-		
-		void serialize(ISerializer &s) {
-			KV_MEMBER(address)
-			KV_MEMBER(message)
-			KV_MEMBER(signature)
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(address)
+      KV_MEMBER(message)
+      KV_MEMBER(signature)
       KV_MEMBER(height)
-		}
-	};
+    }
+  };
 
-	struct response	{
-		bool good;
-		uint64_t total;
-		uint64_t spent;
-		uint64_t locked;
+  struct response {
+    bool good;
+    uint64_t total;
+    uint64_t spent;
+    uint64_t locked;
 
-		void serialize(ISerializer &s) {
-			KV_MEMBER(good)
-			KV_MEMBER(total)
-			KV_MEMBER(spent)
-			KV_MEMBER(locked)
-		}
-	};
+    void serialize(ISerializer &s) {
+      KV_MEMBER(good)
+      KV_MEMBER(total)
+      KV_MEMBER(spent)
+      KV_MEMBER(locked)
+    }
+  };
 };
 
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -1925,13 +1925,16 @@ bool RpcServer::on_verify_message(const COMMAND_RPC_VERIFY_MESSAGE::request& req
     throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Failed to parse address"));
   }
 
+  // could just've used this but detailed errors might be more handy
+  //res.sig_valid = CryptoNote::verifyMessage(req.message, acc, req.signature, logger.getLogger());
+
   std::string decoded;
   Crypto::Signature s;
   uint64_t prefix;
   if (!Tools::Base58::decode_addr(req.signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
     throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature decoding error"));
   }
-  
+
   if (sizeof(s) != decoded.size()) {
     throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature size wrong"));
     return false;
@@ -1942,6 +1945,7 @@ bool RpcServer::on_verify_message(const COMMAND_RPC_VERIFY_MESSAGE::request& req
 
   memcpy(&s, decoded.data(), sizeof(s));
   res.sig_valid = Crypto::check_signature(hash, acc.spendPublicKey, s);
+
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -1921,24 +1921,26 @@ bool RpcServer::on_validate_address(const COMMAND_RPC_VALIDATE_ADDRESS::request&
 }
 
 bool RpcServer::on_verify_message(const COMMAND_RPC_VERIFY_MESSAGE::request& req, COMMAND_RPC_VERIFY_MESSAGE::response& res) {
-	Crypto::Hash hash;
-	Crypto::cn_fast_hash(req.message.data(), req.message.size(), hash);
-
 	AccountPublicAddress acc = boost::value_initialized<AccountPublicAddress>();
 	if (!m_core.currency().parseAccountAddressString(req.address, acc)) {
 		throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Failed to parse address"));
 	}
 
-	const size_t header_len = strlen("SigV1");
-	if (req.signature.size() < header_len || req.signature.substr(0, header_len) != "SigV1") {
-		throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature header check error"));
-	}
 	std::string decoded;
 	Crypto::Signature s;
-	if (!Tools::Base58::decode(req.signature.substr(header_len), decoded) || sizeof(s) != decoded.size()) {
-		throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature decoding error"));
-		return false;
-	}
+	uint64_t prefix;
+  if (!Tools::Base58::decode_addr(req.signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
+    throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature decoding error"));
+  }
+  
+  if (sizeof(s) != decoded.size()) {
+    throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature size wrong"));
+    return false;
+  }
+
+  Crypto::Hash hash;
+  Crypto::cn_fast_hash(req.message.data(), req.message.size(), hash);
+
 	memcpy(&s, decoded.data(), sizeof(s));
 	res.sig_valid = Crypto::check_signature(hash, acc.spendPublicKey, s);
 	res.status = CORE_RPC_STATUS_OK;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -333,7 +333,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
     response.addHeader("Access-Control-Allow-Origin", m_cors_domain);
     response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
     response.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
-  }	
+  }  
 
   JsonRpcRequest jsonRequest;
   JsonRpcResponse jsonResponse;
@@ -344,7 +344,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
     jsonResponse.setId(jsonRequest.getId()); // copy id
 
     static std::unordered_map<std::string, RpcServer::RpcHandler<JsonMemberMethod>> jsonRpcHandlers = {
-	
+  
       { "getblockcount", { makeMemberMethod(&RpcServer::on_getblockcount), true } },
       { "getblockhash", { makeMemberMethod(&RpcServer::on_getblockhash), true } },
       { "getblocktemplate", { makeMemberMethod(&RpcServer::on_getblocktemplate), true } },
@@ -1127,8 +1127,8 @@ bool RpcServer::on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMM
 
 bool RpcServer::on_get_fee_address(const COMMAND_RPC_GET_FEE_ADDRESS::request& req, COMMAND_RPC_GET_FEE_ADDRESS::response& res) {
   if (m_fee_address.empty()) {
-	res.status = CORE_RPC_STATUS_OK;
-	return false; 
+    res.status = CORE_RPC_STATUS_OK;
+    return false; 
   }
   res.fee_address = m_fee_address;
   res.fee_amount = m_fee_amount;
@@ -1265,40 +1265,40 @@ bool RpcServer::on_get_transactions_pool(const COMMAND_RPC_GET_TRANSACTIONS_POOL
 }
 
 bool RpcServer::on_get_transactions_by_payment_id(const COMMAND_RPC_GET_TRANSACTIONS_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTIONS_BY_PAYMENT_ID::response& res) {
-	if (!req.payment_id.size()) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Wrong parameters, expected payment_id" };
-	}
+  if (!req.payment_id.size()) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Wrong parameters, expected payment_id" };
+  }
 
-	Crypto::Hash paymentId;
-	std::vector<Transaction> transactions;
+  Crypto::Hash paymentId;
+  std::vector<Transaction> transactions;
 
-	if (!parse_hash256(req.payment_id, paymentId)) {
-		throw JsonRpc::JsonRpcError{
-			CORE_RPC_ERROR_CODE_WRONG_PARAM,
-			"Failed to parse Payment ID: " + req.payment_id + '.' };
-	}
+  if (!parse_hash256(req.payment_id, paymentId)) {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_WRONG_PARAM,
+      "Failed to parse Payment ID: " + req.payment_id + '.' };
+  }
 
-	if (!m_core.getTransactionsByPaymentId(paymentId, transactions)) {
-		throw JsonRpc::JsonRpcError{
-			CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
-			"Internal error: can't get transactions by Payment ID: " + req.payment_id + '.' };
-	}
+  if (!m_core.getTransactionsByPaymentId(paymentId, transactions)) {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
+      "Internal error: can't get transactions by Payment ID: " + req.payment_id + '.' };
+  }
 
-	for (const Transaction& tx : transactions) {
-		transaction_short_response transaction_short;
-		uint64_t amount_in = 0;
-		get_inputs_money_amount(tx, amount_in);
-		uint64_t amount_out = get_outs_money_amount(tx);
+  for (const Transaction& tx : transactions) {
+    transaction_short_response transaction_short;
+    uint64_t amount_in = 0;
+    get_inputs_money_amount(tx, amount_in);
+    uint64_t amount_out = get_outs_money_amount(tx);
 
-		transaction_short.hash = Common::podToHex(getObjectHash(tx));
-		transaction_short.fee = amount_in - amount_out;
-		transaction_short.amount_out = amount_out;
-		transaction_short.size = getObjectBinarySize(tx);
-		res.transactions.push_back(transaction_short);
-	}
+    transaction_short.hash = Common::podToHex(getObjectHash(tx));
+    transaction_short.fee = amount_in - amount_out;
+    transaction_short.amount_out = amount_out;
+    transaction_short.size = getObjectBinarySize(tx);
+    res.transactions.push_back(transaction_short);
+  }
 
-	res.status = CORE_RPC_STATUS_OK;
-	return true;
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
 }
 
 bool RpcServer::on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res) {
@@ -1385,8 +1385,8 @@ bool RpcServer::on_getblocktemplate(const COMMAND_RPC_GETBLOCKTEMPLATE::request&
 
   BinaryArray hashing_blob;
   if (!get_block_hashing_blob(b, hashing_blob)) {
-	  logger(Logging::ERROR) << "Failed to get blockhashing_blob";
-	  throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: failed to get blockhashing_blob" };
+    logger(Logging::ERROR) << "Failed to get blockhashing_blob";
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: failed to get blockhashing_blob" };
   }
 
   res.blocktemplate_blob = Common::toHex(block_blob);
@@ -1530,348 +1530,348 @@ bool RpcServer::on_get_block_timestamp_by_height(const COMMAND_RPC_GET_BLOCK_TIM
 }
 
 bool RpcServer::on_check_transaction_key(const COMMAND_RPC_CHECK_TRANSACTION_KEY::request& req, COMMAND_RPC_CHECK_TRANSACTION_KEY::response& res) {
-	// parse txid
-	Crypto::Hash txid;
-	if (!parse_hash256(req.transaction_id, txid)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
-	}
-	// parse address
-	CryptoNote::AccountPublicAddress address;
-	if (!m_core.currency().parseAccountAddressString(req.address, address)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
-	}
-	// parse txkey
-	Crypto::Hash tx_key_hash;
-	size_t size;
-	if (!Common::fromHex(req.transaction_key, &tx_key_hash, sizeof(tx_key_hash), size) || size != sizeof(tx_key_hash)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txkey" };
-	}
-	Crypto::SecretKey tx_key = *(struct Crypto::SecretKey *) &tx_key_hash;
+  // parse txid
+  Crypto::Hash txid;
+  if (!parse_hash256(req.transaction_id, txid)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
+  }
+  // parse address
+  CryptoNote::AccountPublicAddress address;
+  if (!m_core.currency().parseAccountAddressString(req.address, address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
+  }
+  // parse txkey
+  Crypto::Hash tx_key_hash;
+  size_t size;
+  if (!Common::fromHex(req.transaction_key, &tx_key_hash, sizeof(tx_key_hash), size) || size != sizeof(tx_key_hash)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txkey" };
+  }
+  Crypto::SecretKey tx_key = *(struct Crypto::SecretKey *) &tx_key_hash;
 
-	// fetch tx
-	Transaction tx;
-	std::vector<Crypto::Hash> tx_ids;
-	tx_ids.push_back(txid);
-	std::list<Crypto::Hash> missed_txs;
-	std::list<Transaction> txs;
-	m_core.getTransactions(tx_ids, txs, missed_txs, true);
+  // fetch tx
+  Transaction tx;
+  std::vector<Crypto::Hash> tx_ids;
+  tx_ids.push_back(txid);
+  std::list<Crypto::Hash> missed_txs;
+  std::list<Transaction> txs;
+  m_core.getTransactions(tx_ids, txs, missed_txs, true);
 
-	if (1 == txs.size()) {
-		tx = txs.front();
-	}
-	else {
-		throw JsonRpc::JsonRpcError{
-			CORE_RPC_ERROR_CODE_WRONG_PARAM,
-			"Couldn't find transaction with hash: " + req.transaction_id + '.' };
-	}
-	CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
+  if (1 == txs.size()) {
+    tx = txs.front();
+  }
+  else {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_WRONG_PARAM,
+      "Couldn't find transaction with hash: " + req.transaction_id + '.' };
+  }
+  CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
 
-	// obtain key derivation
-	Crypto::KeyDerivation derivation;
-	if (!Crypto::generate_key_derivation(address.viewPublicKey, tx_key, derivation))
-	{
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to generate key derivation from supplied parameters" };
-	}
-	
-	// look for outputs
-	uint64_t received(0);
-	size_t keyIndex(0);
-	std::vector<TransactionOutput> outputs;
-	try {
-		for (const TransactionOutput& o : transaction.outputs) {
-			if (o.target.type() == typeid(KeyOutput)) {
-				const KeyOutput out_key = boost::get<KeyOutput>(o.target);
-				Crypto::PublicKey pubkey;
-				derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
-				if (pubkey == out_key.key) {
-					received += o.amount;
-					outputs.push_back(o);
-				}
-			}
-			++keyIndex;
-		}
-	}
-	catch (...)
-	{
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
-	}
-	res.amount = received;
-	res.outputs = outputs;
-	res.status = CORE_RPC_STATUS_OK;
-	return true;
+  // obtain key derivation
+  Crypto::KeyDerivation derivation;
+  if (!Crypto::generate_key_derivation(address.viewPublicKey, tx_key, derivation))
+  {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to generate key derivation from supplied parameters" };
+  }
+  
+  // look for outputs
+  uint64_t received(0);
+  size_t keyIndex(0);
+  std::vector<TransactionOutput> outputs;
+  try {
+    for (const TransactionOutput& o : transaction.outputs) {
+      if (o.target.type() == typeid(KeyOutput)) {
+        const KeyOutput out_key = boost::get<KeyOutput>(o.target);
+        Crypto::PublicKey pubkey;
+        derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
+        if (pubkey == out_key.key) {
+          received += o.amount;
+          outputs.push_back(o);
+        }
+      }
+      ++keyIndex;
+    }
+  }
+  catch (...)
+  {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
+  }
+  res.amount = received;
+  res.outputs = outputs;
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
 }
 
 bool RpcServer::on_check_transaction_with_view_key(const COMMAND_RPC_CHECK_TRANSACTION_WITH_PRIVATE_VIEW_KEY::request& req, COMMAND_RPC_CHECK_TRANSACTION_WITH_PRIVATE_VIEW_KEY::response& res) {
-	// parse txid
-	Crypto::Hash txid;
-	if (!parse_hash256(req.transaction_id, txid)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
-	}
-	// parse address
-	CryptoNote::AccountPublicAddress address;
-	if (!m_core.currency().parseAccountAddressString(req.address, address)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
-	}
-	// parse view key
-	Crypto::Hash view_key_hash;
-	size_t size;
-	if (!Common::fromHex(req.view_key, &view_key_hash, sizeof(view_key_hash), size) || size != sizeof(view_key_hash)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse private view key" };
-	}
-	Crypto::SecretKey viewKey = *(struct Crypto::SecretKey *) &view_key_hash;
+  // parse txid
+  Crypto::Hash txid;
+  if (!parse_hash256(req.transaction_id, txid)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
+  }
+  // parse address
+  CryptoNote::AccountPublicAddress address;
+  if (!m_core.currency().parseAccountAddressString(req.address, address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
+  }
+  // parse view key
+  Crypto::Hash view_key_hash;
+  size_t size;
+  if (!Common::fromHex(req.view_key, &view_key_hash, sizeof(view_key_hash), size) || size != sizeof(view_key_hash)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse private view key" };
+  }
+  Crypto::SecretKey viewKey = *(struct Crypto::SecretKey *) &view_key_hash;
 
-	// fetch tx
-	Transaction tx;
-	std::vector<Crypto::Hash> tx_ids;
-	tx_ids.push_back(txid);
-	std::list<Crypto::Hash> missed_txs;
-	std::list<Transaction> txs;
-	m_core.getTransactions(tx_ids, txs, missed_txs, true);
+  // fetch tx
+  Transaction tx;
+  std::vector<Crypto::Hash> tx_ids;
+  tx_ids.push_back(txid);
+  std::list<Crypto::Hash> missed_txs;
+  std::list<Transaction> txs;
+  m_core.getTransactions(tx_ids, txs, missed_txs, true);
 
-	if (1 == txs.size()) {
-		tx = txs.front();
-	}
-	else {
-		throw JsonRpc::JsonRpcError{
-			CORE_RPC_ERROR_CODE_WRONG_PARAM,
-			"Couldn't find transaction with hash: " + req.transaction_id + '.' };
-	}
-	CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
-	
-	// get tx pub key
-	Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(transaction.extra);
+  if (1 == txs.size()) {
+    tx = txs.front();
+  }
+  else {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_WRONG_PARAM,
+      "Couldn't find transaction with hash: " + req.transaction_id + '.' };
+  }
+  CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
+  
+  // get tx pub key
+  Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(transaction.extra);
 
-	// obtain key derivation
-	Crypto::KeyDerivation derivation;
-	if (!Crypto::generate_key_derivation(txPubKey, viewKey, derivation))
-	{
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to generate key derivation from supplied parameters" };
-	}
+  // obtain key derivation
+  Crypto::KeyDerivation derivation;
+  if (!Crypto::generate_key_derivation(txPubKey, viewKey, derivation))
+  {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to generate key derivation from supplied parameters" };
+  }
 
-	// look for outputs
-	uint64_t received(0);
-	size_t keyIndex(0);
-	std::vector<TransactionOutput> outputs;
-	try {
-		for (const TransactionOutput& o : transaction.outputs) {
-			if (o.target.type() == typeid(KeyOutput)) {
-				const KeyOutput out_key = boost::get<KeyOutput>(o.target);
-				Crypto::PublicKey pubkey;
-				derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
-				if (pubkey == out_key.key) {
-					received += o.amount;
-					outputs.push_back(o);
-				}
-			}
-			++keyIndex;
-		}
-	}
-	catch (...)
-	{
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
-	}
-	res.amount = received;
-	res.outputs = outputs;
-	
-	Crypto::Hash blockHash;
-	uint32_t blockHeight;
-	if (m_core.getBlockContainingTx(txid, blockHash, blockHeight)) {
-		res.confirmations = m_protocolQuery.getObservedHeight() - blockHeight;
-	}
+  // look for outputs
+  uint64_t received(0);
+  size_t keyIndex(0);
+  std::vector<TransactionOutput> outputs;
+  try {
+    for (const TransactionOutput& o : transaction.outputs) {
+      if (o.target.type() == typeid(KeyOutput)) {
+        const KeyOutput out_key = boost::get<KeyOutput>(o.target);
+        Crypto::PublicKey pubkey;
+        derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
+        if (pubkey == out_key.key) {
+          received += o.amount;
+          outputs.push_back(o);
+        }
+      }
+      ++keyIndex;
+    }
+  }
+  catch (...)
+  {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
+  }
+  res.amount = received;
+  res.outputs = outputs;
+  
+  Crypto::Hash blockHash;
+  uint32_t blockHeight;
+  if (m_core.getBlockContainingTx(txid, blockHash, blockHeight)) {
+    res.confirmations = m_protocolQuery.getObservedHeight() - blockHeight;
+  }
 
-	res.status = CORE_RPC_STATUS_OK;
-	return true;
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
 }
 
 bool RpcServer::on_check_transaction_proof(const COMMAND_RPC_CHECK_TRANSACTION_PROOF::request& req, COMMAND_RPC_CHECK_TRANSACTION_PROOF::response& res) {
-	// parse txid
-	Crypto::Hash txid;
-	if (!parse_hash256(req.transaction_id, txid)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
-	}
-	// parse address
-	CryptoNote::AccountPublicAddress address;
-	if (!m_core.currency().parseAccountAddressString(req.destination_address, address)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.destination_address + '.' };
-	}
-	// parse pubkey r*A & signature
-	std::string decoded_data;
-	uint64_t prefix;
-	if (!Tools::Base58::decode_addr(req.signature, prefix, decoded_data) || prefix != CryptoNote::parameters::CRYPTONOTE_TX_PROOF_BASE58_PREFIX) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Transaction proof decoding error" };
-	}
-	Crypto::PublicKey rA;
-	Crypto::Signature sig;
-	std::string rA_decoded = decoded_data.substr(0, sizeof(Crypto::PublicKey));
-	std::string sig_decoded = decoded_data.substr(sizeof(Crypto::PublicKey), sizeof(Crypto::Signature));
+  // parse txid
+  Crypto::Hash txid;
+  if (!parse_hash256(req.transaction_id, txid)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse txid" };
+  }
+  // parse address
+  CryptoNote::AccountPublicAddress address;
+  if (!m_core.currency().parseAccountAddressString(req.destination_address, address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.destination_address + '.' };
+  }
+  // parse pubkey r*A & signature
+  std::string decoded_data;
+  uint64_t prefix;
+  if (!Tools::Base58::decode_addr(req.signature, prefix, decoded_data) || prefix != CryptoNote::parameters::CRYPTONOTE_TX_PROOF_BASE58_PREFIX) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Transaction proof decoding error" };
+  }
+  Crypto::PublicKey rA;
+  Crypto::Signature sig;
+  std::string rA_decoded = decoded_data.substr(0, sizeof(Crypto::PublicKey));
+  std::string sig_decoded = decoded_data.substr(sizeof(Crypto::PublicKey), sizeof(Crypto::Signature));
 
-	memcpy(&rA, rA_decoded.data(), sizeof(Crypto::PublicKey));
-	memcpy(&sig, sig_decoded.data(), sizeof(Crypto::Signature));
+  memcpy(&rA, rA_decoded.data(), sizeof(Crypto::PublicKey));
+  memcpy(&sig, sig_decoded.data(), sizeof(Crypto::Signature));
 
-	// fetch tx pubkey
-	Transaction tx;
+  // fetch tx pubkey
+  Transaction tx;
 
-	std::vector<uint32_t> out;
-	std::vector<Crypto::Hash> tx_ids;
-	tx_ids.push_back(txid);
-	std::list<Crypto::Hash> missed_txs;
-	std::list<Transaction> txs;
-	m_core.getTransactions(tx_ids, txs, missed_txs, true);
+  std::vector<uint32_t> out;
+  std::vector<Crypto::Hash> tx_ids;
+  tx_ids.push_back(txid);
+  std::list<Crypto::Hash> missed_txs;
+  std::list<Transaction> txs;
+  m_core.getTransactions(tx_ids, txs, missed_txs, true);
 
-	if (1 == txs.size()) {
-		tx = txs.front();
-	}
-	else {
-		throw JsonRpc::JsonRpcError{
-			CORE_RPC_ERROR_CODE_WRONG_PARAM,
-			"transaction wasn't found. Hash = " + req.transaction_id + '.' };
-	}
-	CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
+  if (1 == txs.size()) {
+    tx = txs.front();
+  }
+  else {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_WRONG_PARAM,
+      "transaction wasn't found. Hash = " + req.transaction_id + '.' };
+  }
+  CryptoNote::TransactionPrefix transaction = *static_cast<const TransactionPrefix*>(&tx);
 
-	Crypto::PublicKey R = getTransactionPublicKeyFromExtra(transaction.extra);
-	if (R == NULL_PUBLIC_KEY)
-	{
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Tx pubkey was not found" };
-	}
+  Crypto::PublicKey R = getTransactionPublicKeyFromExtra(transaction.extra);
+  if (R == NULL_PUBLIC_KEY)
+  {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Tx pubkey was not found" };
+  }
 
-	// check signature
-	bool r = Crypto::check_tx_proof(txid, R, address.viewPublicKey, rA, sig);
-	res.signature_valid = r;
+  // check signature
+  bool r = Crypto::check_tx_proof(txid, R, address.viewPublicKey, rA, sig);
+  res.signature_valid = r;
 
-	if (r) {
+  if (r) {
 
-		// obtain key derivation by multiplying scalar 1 to the pubkey r*A included in the signature
-		Crypto::KeyDerivation derivation;
-		if (!Crypto::generate_key_derivation(rA, Crypto::EllipticCurveScalar2SecretKey(Crypto::I), derivation)) {
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
-		}
+    // obtain key derivation by multiplying scalar 1 to the pubkey r*A included in the signature
+    Crypto::KeyDerivation derivation;
+    if (!Crypto::generate_key_derivation(rA, Crypto::EllipticCurveScalar2SecretKey(Crypto::I), derivation)) {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
+    }
 
-		// look for outputs
-		uint64_t received(0);
-		size_t keyIndex(0);
-		std::vector<TransactionOutput> outputs;
-		try {
-			for (const TransactionOutput& o : transaction.outputs) {
-				if (o.target.type() == typeid(KeyOutput)) {
-					const KeyOutput out_key = boost::get<KeyOutput>(o.target);
-					Crypto::PublicKey pubkey;
-					derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
-					if (pubkey == out_key.key) {
-						received += o.amount;
-						outputs.push_back(o);
-					}
-				}
-				++keyIndex;
-			}
-		}
-		catch (...)
-		{
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
-		}
-		res.received_amount = received;
-		res.outputs = outputs;
+    // look for outputs
+    uint64_t received(0);
+    size_t keyIndex(0);
+    std::vector<TransactionOutput> outputs;
+    try {
+      for (const TransactionOutput& o : transaction.outputs) {
+        if (o.target.type() == typeid(KeyOutput)) {
+          const KeyOutput out_key = boost::get<KeyOutput>(o.target);
+          Crypto::PublicKey pubkey;
+          derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
+          if (pubkey == out_key.key) {
+            received += o.amount;
+            outputs.push_back(o);
+          }
+        }
+        ++keyIndex;
+      }
+    }
+    catch (...)
+    {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
+    }
+    res.received_amount = received;
+    res.outputs = outputs;
 
-		Crypto::Hash blockHash;
-		uint32_t blockHeight;
-		if (m_core.getBlockContainingTx(txid, blockHash, blockHeight)) {
-			res.confirmations = m_protocolQuery.getObservedHeight() - blockHeight;
-		}
-	}
-	else {
-		res.received_amount = 0;
-	}
+    Crypto::Hash blockHash;
+    uint32_t blockHeight;
+    if (m_core.getBlockContainingTx(txid, blockHash, blockHeight)) {
+      res.confirmations = m_protocolQuery.getObservedHeight() - blockHeight;
+    }
+  }
+  else {
+    res.received_amount = 0;
+  }
 
-	res.status = CORE_RPC_STATUS_OK;
-	return true;
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
 }
 
 bool RpcServer::on_check_reserve_proof(const COMMAND_RPC_CHECK_RESERVE_PROOF::request& req, COMMAND_RPC_CHECK_RESERVE_PROOF::response& res) {
-	// parse address
-	CryptoNote::AccountPublicAddress address;
-	if (!m_core.currency().parseAccountAddressString(req.address, address)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
-	}
-	
-	// parse sugnature
-	std::string decoded_data;
-	uint64_t prefix;
-	if (!Tools::Base58::decode_addr(req.signature, prefix, decoded_data) || prefix != CryptoNote::parameters::CRYPTONOTE_RESERVE_PROOF_BASE58_PREFIX) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Reserve proof decoding error" };
-	}
-	BinaryArray ba(decoded_data.begin(), decoded_data.end());
-	reserve_proof proof_decoded;
-	if (!fromBinaryArray(proof_decoded, ba)) {
-		throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Reserve proof BinaryArray decoding error" };
-	}
+  // parse address
+  CryptoNote::AccountPublicAddress address;
+  if (!m_core.currency().parseAccountAddressString(req.address, address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
+  }
+  
+  // parse sugnature
+  std::string decoded_data;
+  uint64_t prefix;
+  if (!Tools::Base58::decode_addr(req.signature, prefix, decoded_data) || prefix != CryptoNote::parameters::CRYPTONOTE_RESERVE_PROOF_BASE58_PREFIX) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Reserve proof decoding error" };
+  }
+  BinaryArray ba(decoded_data.begin(), decoded_data.end());
+  reserve_proof proof_decoded;
+  if (!fromBinaryArray(proof_decoded, ba)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Reserve proof BinaryArray decoding error" };
+  }
 
-	std::vector<reserve_proof_entry>& proofs = proof_decoded.proofs;
-	
-	// compute signature prefix hash
-	std::string prefix_data = req.message;
-	prefix_data.append((const char*)&address, sizeof(CryptoNote::AccountPublicAddress));
-	for (size_t i = 0; i < proofs.size(); ++i) {
-		prefix_data.append((const char*)&proofs[i].key_image, sizeof(Crypto::PublicKey));
-	}
-	Crypto::Hash prefix_hash;
-	Crypto::cn_fast_hash(prefix_data.data(), prefix_data.size(), prefix_hash);
+  std::vector<reserve_proof_entry>& proofs = proof_decoded.proofs;
+  
+  // compute signature prefix hash
+  std::string prefix_data = req.message;
+  prefix_data.append((const char*)&address, sizeof(CryptoNote::AccountPublicAddress));
+  for (size_t i = 0; i < proofs.size(); ++i) {
+    prefix_data.append((const char*)&proofs[i].key_image, sizeof(Crypto::PublicKey));
+  }
+  Crypto::Hash prefix_hash;
+  Crypto::cn_fast_hash(prefix_data.data(), prefix_data.size(), prefix_hash);
 
-	// fetch txes
-	std::vector<Crypto::Hash> transactionHashes;
-	for (size_t i = 0; i < proofs.size(); ++i) {
-		transactionHashes.push_back(proofs[i].transaction_id);
-	}
-	std::list<Crypto::Hash> missed_txs;
-	std::list<Transaction> txs;
-	m_core.getTransactions(transactionHashes, txs, missed_txs);
-	std::vector<Transaction> transactions;
-	std::copy(txs.begin(), txs.end(), std::inserter(transactions, transactions.end()));
+  // fetch txes
+  std::vector<Crypto::Hash> transactionHashes;
+  for (size_t i = 0; i < proofs.size(); ++i) {
+    transactionHashes.push_back(proofs[i].transaction_id);
+  }
+  std::list<Crypto::Hash> missed_txs;
+  std::list<Transaction> txs;
+  m_core.getTransactions(transactionHashes, txs, missed_txs);
+  std::vector<Transaction> transactions;
+  std::copy(txs.begin(), txs.end(), std::inserter(transactions, transactions.end()));
 
-	// check spent status
-	res.total = 0;
-	res.spent = 0;
-	res.locked = 0;
-	for (size_t i = 0; i < proofs.size(); ++i) {
-		const reserve_proof_entry& proof = proofs[i];
+  // check spent status
+  res.total = 0;
+  res.spent = 0;
+  res.locked = 0;
+  for (size_t i = 0; i < proofs.size(); ++i) {
+    const reserve_proof_entry& proof = proofs[i];
 
-		CryptoNote::TransactionPrefix tx = *static_cast<const TransactionPrefix*>(&transactions[i]);
+    CryptoNote::TransactionPrefix tx = *static_cast<const TransactionPrefix*>(&transactions[i]);
     
-		bool unlocked = m_core.is_tx_spendtime_unlocked(tx.unlockTime, req.height);
+    bool unlocked = m_core.is_tx_spendtime_unlocked(tx.unlockTime, req.height);
 
-		if (proof.index_in_transaction >= tx.outputs.size()) {
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "index_in_tx is out of bound" };
-		}
+    if (proof.index_in_transaction >= tx.outputs.size()) {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "index_in_tx is out of bound" };
+    }
 
-		const KeyOutput out_key = boost::get<KeyOutput>(tx.outputs[proof.index_in_transaction].target);
+    const KeyOutput out_key = boost::get<KeyOutput>(tx.outputs[proof.index_in_transaction].target);
 
-		// get tx pub key
-		Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
+    // get tx pub key
+    Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
 
-		// check singature for shared secret
-		if (!Crypto::check_tx_proof(prefix_hash, address.viewPublicKey, txPubKey, proof.shared_secret, proof.shared_secret_sig)) {
-			//throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to check singature for shared secret" };
-			res.good = false;
-			return true;
-		}
+    // check singature for shared secret
+    if (!Crypto::check_tx_proof(prefix_hash, address.viewPublicKey, txPubKey, proof.shared_secret, proof.shared_secret_sig)) {
+      //throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to check singature for shared secret" };
+      res.good = false;
+      return true;
+    }
 
-		// check signature for key image
-		const std::vector<const Crypto::PublicKey *>& pubs = { &out_key.key };
-		if (!Crypto::check_ring_signature(prefix_hash, proof.key_image, &pubs[0], 1, &proof.key_image_sig)) {
-			//throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to check signature for key image" };
-			res.good = false;
-			return true;
-		}
+    // check signature for key image
+    const std::vector<const Crypto::PublicKey *>& pubs = { &out_key.key };
+    if (!Crypto::check_ring_signature(prefix_hash, proof.key_image, &pubs[0], 1, &proof.key_image_sig)) {
+      //throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to check signature for key image" };
+      res.good = false;
+      return true;
+    }
 
-		// check if the address really received the fund
-		Crypto::KeyDerivation derivation;
-		if (!Crypto::generate_key_derivation(proof.shared_secret, Crypto::EllipticCurveScalar2SecretKey(Crypto::I), derivation)) {
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
-		}
-		try {
-			Crypto::PublicKey pubkey;
-			derive_public_key(derivation, proof.index_in_transaction, address.spendPublicKey, pubkey);
-			if (pubkey == out_key.key) {
-				uint64_t amount = tx.outputs[proof.index_in_transaction].amount;
-				res.total += amount;
+    // check if the address really received the fund
+    Crypto::KeyDerivation derivation;
+    if (!Crypto::generate_key_derivation(proof.shared_secret, Crypto::EllipticCurveScalar2SecretKey(Crypto::I), derivation)) {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
+    }
+    try {
+      Crypto::PublicKey pubkey;
+      derive_public_key(derivation, proof.index_in_transaction, address.spendPublicKey, pubkey);
+      if (pubkey == out_key.key) {
+        uint64_t amount = tx.outputs[proof.index_in_transaction].amount;
+        res.total += amount;
 
         if (!unlocked) {
           res.locked += amount;
@@ -1885,26 +1885,25 @@ bool RpcServer::on_check_reserve_proof(const COMMAND_RPC_CHECK_RESERVE_PROOF::re
           if (m_core.is_key_image_spent(proof.key_image)) {
             res.spent += amount;
           }
-				}
-			}
-		}
-		catch (...)
-		{
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
-		}
-		
-	}
+        }
+      }
+    }
+    catch (...)
+    {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
+    }  
+  }
 
-	// check signature for address spend keys
-	Crypto::Signature sig = proof_decoded.signature;
-	if (!Crypto::check_signature(prefix_hash, address.spendPublicKey, sig)) {
-		res.good = false;
-		return true;
-	}
+  // check signature for address spend keys
+  Crypto::Signature sig = proof_decoded.signature;
+  if (!Crypto::check_signature(prefix_hash, address.spendPublicKey, sig)) {
+    res.good = false;
+    return true;
+  }
 
-	res.good = true;
+  res.good = true;
 
-	return true;
+  return true;
 }
 
 bool RpcServer::on_validate_address(const COMMAND_RPC_VALIDATE_ADDRESS::request& req, COMMAND_RPC_VALIDATE_ADDRESS::response& res) {
@@ -1921,14 +1920,14 @@ bool RpcServer::on_validate_address(const COMMAND_RPC_VALIDATE_ADDRESS::request&
 }
 
 bool RpcServer::on_verify_message(const COMMAND_RPC_VERIFY_MESSAGE::request& req, COMMAND_RPC_VERIFY_MESSAGE::response& res) {
-	AccountPublicAddress acc = boost::value_initialized<AccountPublicAddress>();
-	if (!m_core.currency().parseAccountAddressString(req.address, acc)) {
-		throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Failed to parse address"));
-	}
+  AccountPublicAddress acc = boost::value_initialized<AccountPublicAddress>();
+  if (!m_core.currency().parseAccountAddressString(req.address, acc)) {
+    throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Failed to parse address"));
+  }
 
-	std::string decoded;
-	Crypto::Signature s;
-	uint64_t prefix;
+  std::string decoded;
+  Crypto::Signature s;
+  uint64_t prefix;
   if (!Tools::Base58::decode_addr(req.signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
     throw JsonRpc::JsonRpcError(CORE_RPC_ERROR_CODE_WRONG_PARAM, std::string("Signature decoding error"));
   }
@@ -1941,10 +1940,10 @@ bool RpcServer::on_verify_message(const COMMAND_RPC_VERIFY_MESSAGE::request& req
   Crypto::Hash hash;
   Crypto::cn_fast_hash(req.message.data(), req.message.size(), hash);
 
-	memcpy(&s, decoded.data(), sizeof(s));
-	res.sig_valid = Crypto::check_signature(hash, acc.spendPublicKey, s);
-	res.status = CORE_RPC_STATUS_OK;
-	return true;
+  memcpy(&s, decoded.data(), sizeof(s));
+  res.sig_valid = Crypto::check_signature(hash, acc.spendPublicKey, s);
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
 }
 
 }

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2321,25 +2321,12 @@ bool simple_wallet::verify_message(const std::vector<std::string> &args) {
     fail_msg_writer() << "failed to parse address " << address_string;
 	return true;
   }
-  const size_t header_len = strlen("SigV1");
-  if (signature.size() < header_len || signature.substr(0, header_len) != "SigV1") {
-    fail_msg_writer() << ("Signature header check error");
-    return false;
-  }
-  std::string decoded;
-  if (!Tools::Base58::decode(signature.substr(header_len), decoded)) {
-    fail_msg_writer() << ("Signature decoding error");
-    return false;
-  }
-  if (sizeof(Crypto::Signature) != decoded.size()) {
-    fail_msg_writer() << ("Signature decoding error");
-    return false;
-  }
+  
   bool r = m_wallet->verify_message(message, address, signature);
   if (!r) {
     fail_msg_writer() << "Invalid signature from " << address_string;
   } else {
-    success_msg_writer() << "Valid signature from " << address_string;
+    success_msg_writer(true) << "Valid signature from " << address_string;
   }
   return true;
 }

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -2857,6 +2857,50 @@ std::string WalletGreen::getReserveProof(const uint64_t &reserve, const std::str
   return reserveProof;
 }
 
+std::string WalletGreen::signMessage(const std::string &message, const std::string& address) {
+  throwIfNotInitialized();
+  throwIfTrackingMode();
+  throwIfStopped();
+
+  WalletRecord wallet;
+
+  if (!address.empty()) {
+    wallet = getWalletRecord(address);
+  }
+  else {
+    if (!m_walletsContainer.empty()) {
+      wallet = m_walletsContainer.get<RandomAccessIndex>()[0];
+    }
+    else {
+      throw std::system_error(make_error_code(CryptoNote::error::BAD_ADDRESS));
+    }
+  }
+
+  CryptoNote::AccountKeys keys;
+  keys.spendSecretKey = wallet.spendSecretKey;
+  keys.viewSecretKey = m_viewSecretKey;
+  keys.address.viewPublicKey = m_viewPublicKey;
+  keys.address.spendPublicKey = wallet.spendPublicKey;
+
+  return CryptoNote::signMessage(message, keys);
+}
+
+bool WalletGreen::verifyMessage(const std::string &message, const std::string& address, const std::string &signature) {
+  throwIfNotInitialized();
+  throwIfStopped();
+
+  try {
+    CryptoNote::AccountPublicAddress pubAddr = parseAddress(address);
+
+    return CryptoNote::verifyMessage(message, pubAddr, signature, m_logger.getLogger());
+  }
+  catch (const std::exception& e) {
+    m_logger(ERROR, BRIGHT_RED) << "Failed to verify message: " << e.what();
+  }
+
+  return false;
+}
+
 void WalletGreen::start() {
   m_logger(INFO, BRIGHT_WHITE) << "Starting container";
   m_stopped = false;

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -101,6 +101,9 @@ public:
 
   virtual std::string getReserveProof(const uint64_t &reserve, const std::string& address, const std::string &message) override;
 
+  virtual std::string signMessage(const std::string &message, const std::string& address) override;
+  virtual bool verifyMessage(const std::string &message, const std::string& address, const std::string &signature) override;
+
   virtual size_t transfer(const TransactionParameters& sendingTransaction, Crypto::SecretKey& txSecretKey) override;
 
   virtual size_t makeTransaction(const TransactionParameters& sendingTransaction) override;

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -513,9 +513,9 @@ bool wallet_rpc_server::on_gen_paymentid(const wallet_rpc::COMMAND_RPC_GEN_PAYME
 	wallet_rpc::COMMAND_RPC_GEN_PAYMENT_ID::response& res) {
 	std::string pid;
 	try {
-    Crypto::Hash result;
-    Random::randomBytes(32, result.data);
-    pid = Common::podToHex(result);
+		Crypto::Hash result;
+		Random::randomBytes(32, result.data);
+		pid = Common::podToHex(result);
 	}
 	catch (const std::exception& e) {
 		throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR, std::string("Internal error: can't generate Payment ID: ") + e.what());
@@ -610,32 +610,32 @@ bool wallet_rpc_server::on_get_reserve_proof(const wallet_rpc::COMMAND_RPC_GET_B
 //------------------------------------------------------------------------------------------------------------------------------
 bool wallet_rpc_server::on_sign_message(const wallet_rpc::COMMAND_RPC_SIGN_MESSAGE::request& req, wallet_rpc::COMMAND_RPC_SIGN_MESSAGE::response& res)
 {
-    res.signature = m_wallet.sign_message(req.message);
-    return true;
+	res.signature = m_wallet.sign_message(req.message);
+	return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
 bool wallet_rpc_server::on_verify_message(const wallet_rpc::COMMAND_RPC_VERIFY_MESSAGE::request& req, wallet_rpc::COMMAND_RPC_VERIFY_MESSAGE::response& res)
 {
-    CryptoNote::AccountPublicAddress address;
+	CryptoNote::AccountPublicAddress address;
 	if (!m_currency.parseAccountAddressString(req.address, address)) {
 		throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_ADDRESS, std::string("Failed to parse address"));
 	}
-	
-  std::string decoded;
-  Crypto::Signature s;
-  uint64_t prefix;
-  if (!Tools::Base58::decode_addr(req.signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
-    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE, std::string("Signature decoding error"));
-  }
 
-  if (sizeof(s) != decoded.size()) {
-    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE, std::string("Signature size wrong"));
-    return false;
-  }
+	std::string decoded;
+	Crypto::Signature s;
+	uint64_t prefix;
+	if (!Tools::Base58::decode_addr(req.signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
+		throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE, std::string("Signature decoding error"));
+	}
 
-  res.good = m_wallet.verify_message(req.message, address, req.signature);
-  return true;
+	if (sizeof(s) != decoded.size()) {
+		throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE, std::string("Signature size wrong"));
+		return false;
+	}
+
+	res.good = m_wallet.verify_message(req.message, address, req.signature);
+	return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -485,11 +485,11 @@ bool wallet_rpc_server::on_validate_address(const wallet_rpc::COMMAND_RPC_VALIDA
 {
 	AccountPublicAddress acc = boost::value_initialized<AccountPublicAddress>();
 	bool r = m_currency.parseAccountAddressString(req.address, acc);
-	res.isvalid = r;
+	res.is_valid = r;
 	if (r) {
 		res.address = m_currency.accountAddressAsString(acc);
-		res.spendPublicKey = Common::podToHex(acc.spendPublicKey);
-		res.viewPublicKey = Common::podToHex(acc.viewPublicKey);
+		res.spend_public_key = Common::podToHex(acc.spendPublicKey);
+		res.view_public_key = Common::podToHex(acc.viewPublicKey);
 	}
 	res.status = CORE_RPC_STATUS_OK;
 	return true;

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -474,17 +474,17 @@ using CryptoNote::ISerializer;
 		};
 
 		struct response {
-			bool isvalid;
+			bool is_valid;
 			std::string address;
-			std::string spendPublicKey;
-			std::string viewPublicKey;
+			std::string spend_public_key;
+			std::string view_public_key;
 			std::string status;
 
 			void serialize(ISerializer &s) {
-				KV_MEMBER(isvalid)
+				KV_MEMBER(is_valid)
 				KV_MEMBER(address)
-				KV_MEMBER(spendPublicKey)
-				KV_MEMBER(viewPublicKey)
+				KV_MEMBER(spend_public_key)
+				KV_MEMBER(view_public_key)
 				KV_MEMBER(status)
 			}
 		};

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -552,33 +552,11 @@ std::string WalletLegacy::getAddress() {
 }
 
 std::string WalletLegacy::sign_message(const std::string &message) {
-  Crypto::Hash hash;
-  Crypto::cn_fast_hash(message.data(), message.size(), hash);
-  const CryptoNote::AccountKeys &keys = m_account.getAccountKeys();
-  Crypto::Signature signature;
-  Crypto::generate_signature(hash, keys.address.spendPublicKey, keys.spendSecretKey, signature);
-  return Tools::Base58::encode_addr(CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX, std::string((const char *)&signature, sizeof(signature)));
+  return CryptoNote::signMessage(message, m_account.getAccountKeys());
 }
 
 bool WalletLegacy::verify_message(const std::string &message, const CryptoNote::AccountPublicAddress &address, const std::string &signature) {
-  std::string decoded;
-  uint64_t prefix;
-  if (!Tools::Base58::decode_addr(signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
-    m_logger(Logging::ERROR) << "Signature decoding error";
-    return false;
-  }
-
-  Crypto::Signature s;
-  if (sizeof(s) != decoded.size()) {
-    m_logger(Logging::ERROR) << "Signature size wrong";
-    return false;
-  }
-
-  Crypto::Hash hash;
-  Crypto::cn_fast_hash(message.data(), message.size(), hash);
-
-  memcpy(&s, decoded.data(), sizeof(s));
-  return Crypto::check_signature(hash, address.spendPublicKey, s);
+  return CryptoNote::verifyMessage(message, address, signature, m_logger.getLogger());
 }
 
 std::vector<Payments> WalletLegacy::getTransactionsByPaymentIds(const std::vector<PaymentId>& paymentIds) const {

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -557,27 +557,26 @@ std::string WalletLegacy::sign_message(const std::string &message) {
   const CryptoNote::AccountKeys &keys = m_account.getAccountKeys();
   Crypto::Signature signature;
   Crypto::generate_signature(hash, keys.address.spendPublicKey, keys.spendSecretKey, signature);
-  return std::string("SigV1") + Tools::Base58::encode(std::string((const char *)&signature, sizeof(signature)));
+  return Tools::Base58::encode_addr(CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX, std::string((const char *)&signature, sizeof(signature)));
 }
 
 bool WalletLegacy::verify_message(const std::string &message, const CryptoNote::AccountPublicAddress &address, const std::string &signature) {
-  const size_t header_len = strlen("SigV1");
-  if (signature.size() < header_len || signature.substr(0, header_len) != "SigV1") {
-    m_logger(Logging::ERROR) << "Signature header check error";
-    return false;
-  }
-  Crypto::Hash hash;
-  Crypto::cn_fast_hash(message.data(), message.size(), hash);
   std::string decoded;
-  if (!Tools::Base58::decode(signature.substr(header_len), decoded)) {
+  uint64_t prefix;
+  if (!Tools::Base58::decode_addr(signature, prefix, decoded) || prefix != CryptoNote::parameters::CRYPTONOTE_KEYS_SIGNATURE_BASE58_PREFIX) {
     m_logger(Logging::ERROR) << "Signature decoding error";
     return false;
   }
+
   Crypto::Signature s;
   if (sizeof(s) != decoded.size()) {
-    m_logger(Logging::ERROR) << "Signature decoding error";
+    m_logger(Logging::ERROR) << "Signature size wrong";
     return false;
   }
+
+  Crypto::Hash hash;
+  Crypto::cn_fast_hash(message.data(), message.size(), hash);
+
   memcpy(&s, decoded.data(), sizeof(s));
   return Crypto::check_signature(hash, address.spendPublicKey, s);
 }

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -121,8 +121,8 @@ public:
   virtual std::vector<TransactionOutputInformation> getTransactionInputs(const Crypto::Hash& transactionHash, uint32_t flags) const override;
   virtual bool isFusionTransaction(const WalletLegacyTransaction& walletTx) const override;
 
-  virtual std::string sign_message(const std::string &data) override;
-  virtual bool verify_message(const std::string &data, const CryptoNote::AccountPublicAddress &address, const std::string &signature) override;
+  virtual std::string sign_message(const std::string &message) override;
+  virtual bool verify_message(const std::string &message, const CryptoNote::AccountPublicAddress &address, const std::string &signature) override;
 
   virtual bool isTrackingWallet() override;
 


### PR DESCRIPTION
* Proper Base58 encoding of signatures in sign/verify message;
* Added support to WalletGreen;
* Implemented sign/verify message functionality in *greenwallet*;
* Implemented sign/verify message functionality in *walletd*;
* Code clean-up;
* On occasion renamed params in *simplewallet* RPC `validate_address` method to under_scores from camelCase to unify with the rest;

**Payment Gate (*walletd*) will receive these new JSON RPC methods:** 
(can be copied as is straight to Wiki when merged)

Sign message
------------

**signMessage()** allows to sign message with wallet keys.

Input:

| Argument        | Mandatory | Description                         | Format | Example                                                          |
|-----------------|-----------|-------------------------------------|--------|------------------------------------------------------------------|
| address         | No        | Public address for keys used to sign message | string |                                                         |
| message         | Yes       | The message to sign                 | string | test                                                             |

**Note:** if **address** is not provided, default main (first) address is used to sign the message.

Output:

| Argument          | Description                                               | Format  | Example   |
|-------------------|-----------------------------------------------------------|---------|-----------|
| adddress          | Address, used to sing the message (useful in case it was omitted in request) | string | |
| signature         | The signature generated with wallet keys                  | string  | SigV16DzpgqS3dQJZMLcTfjhFivsYjC7UCkUdS1DLFUujUkHdyoRnADcpPjv66JXgeQU5ujTc5UnEPTfwDqJTUSXUUg5jM2MmRi |

Input example:

```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "signMessage",
  "params":{
    "message":"test"
  }
}
```

Output example:

```
{
   "id":"test",
   "jsonrpc":"2.0",
   "result":{
      "address":"Kcwr4Awjn7QefxbAEvHSAcTrVbhzYukfmbDvwWkrDhjFXe1FVUj5ggxCrEv4w2zv6iVZgoF4v7b3cNAbaU3LKQGS9EU9KAd",
      "signature":"SigV16DzpgqS3dQJZMLcTfjhFivsYjC7UCkUdS1DLFUujUkHdyoRnADcpPjv66JXgeQU5ujTc5UnEPTfwDqJTUSXUUg5jM2MmRi"
   }
}
```


Verify message
--------------

**verifyMessage()** method is used to verify signed message.

Input:

| Argument        | Mandatory | Description                         | Format | Example                                                          |
|-----------------|-----------|-------------------------------------|--------|------------------------------------------------------------------|
| address         | Yes       | Public address for keys used to sign message | string | |
| message         | Yes       | The message to sign | string | |
| signature       | Yes       | The signature | string | SigV16DzpgqS3dQJZMLcTfjhFivsYjC7UCkUdS1DLFUujUkHdyoRnADcpPjv66JXgeQU5ujTc5UnEPTfwDqJTUSXUUg5jM2MmRi |


Output:

| Argument          | Description                                               | Format  | Example   |
|-------------------|-----------------------------------------------------------|---------|-----------|
| isValid           | Denotes whether signature of message is valid or not      | boolean | See below |


Input example:

```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "verifyMessage",
  "params":{
    "address":"Kcwr4Awjn7QefxbAEvHSAcTrVbhzYukfmbDvwWkrDhjFXe1FVUj5ggxCrEv4w2zv6iVZgoF4v7b3cNAbaU3LKQGS9EU9KAd",
    "message":"test",
    "signature":"SigV16DzpgqS3dQJZMLcTfjhFivsYjC7UCkUdS1DLFUujUkHdyoRnADcpPjv66JXgeQU5ujTc5UnEPTfwDqJTUSXUUg5jM2MmRi"
  }
}
```
Output example:

```
{
   "id":"test",
   "jsonrpc":"2.0",
   "result":{
      "isValid":true
   }
}
```