### PR TITLE
New RPC method gettransactionsbyheights

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -1018,6 +1018,35 @@ struct COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH {
   };
 };
 
+struct COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HEIGHTS {
+  struct request {
+    std::vector<uint32_t> heights;
+    bool include_miner_txs = true;
+    bool exclude_signatures = true;
+    bool range = false;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(heights)
+      KV_MEMBER(include_miner_txs)
+      KV_MEMBER(exclude_signatures)
+      KV_MEMBER(range)
+    };
+  };
+
+  struct response {
+    std::vector<TransactionDetails> transactions;
+    std::list<std::string> missed_txs;
+    std::string status;
+
+    void serialize(ISerializer &s)
+    {
+      KV_MEMBER(transactions)
+      KV_MEMBER(missed_txs)
+      KV_MEMBER(status)       
+    }
+  };
+};
+
 //-----------------------------------------------
 struct reserve_proof_entry
 {

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -167,6 +167,7 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   { "/get_blocks_hashes_by_timestamps", { jsonMethod<COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS>(&RpcServer::on_get_blocks_hashes_by_timestamps), true } },
   { "/get_transaction_details_by_hashes", { jsonMethod<COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HASHES>(&RpcServer::on_get_transactions_details_by_hashes), true } },
   { "/get_transaction_details_by_hash", { jsonMethod<COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH>(&RpcServer::on_get_transaction_details_by_hash), true } },
+  { "/get_transaction_details_by_heights", { jsonMethod<COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HEIGHTS>(&RpcServer::on_get_transactions_details_by_heights), true } },
   { "/get_transaction_hashes_by_payment_id", { jsonMethod<COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID>(&RpcServer::on_get_transaction_hashes_by_paymentid), true } },
   
   // disabled in restricted rpc mode
@@ -366,6 +367,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
       { "gettransactionsbypaymentid", { makeMemberMethod(&RpcServer::on_get_transactions_by_payment_id), true } },
       { "gettransactionhashesbypaymentid", { makeMemberMethod(&RpcServer::on_get_transaction_hashes_by_paymentid), true } },
       { "gettransactionsbyhashes", { makeMemberMethod(&RpcServer::on_get_transactions_details_by_hashes), true } },
+      { "gettransactionsbyheights", { makeMemberMethod(&RpcServer::on_get_transactions_details_by_heights), true } },
       { "getcurrencyid", { makeMemberMethod(&RpcServer::on_get_currency_id), true } },
       { "getstatsbyheights", { makeMemberMethod(&RpcServer::on_get_stats_by_heights), false } },
       { "getstatsinrange", { makeMemberMethod(&RpcServer::on_get_stats_by_heights_range), false } },
@@ -846,6 +848,94 @@ bool RpcServer::on_get_transaction_details_by_hash(const COMMAND_RPC_GET_TRANSAC
     }
 
     rsp.transaction = std::move(transactionsDetails);
+  }
+  catch (std::system_error& e) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, e.what() };
+    return false;
+  }
+  catch (std::exception& e) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Error: " + std::string(e.what()) };
+    return false;
+  }
+  rsp.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_get_transactions_details_by_heights(const COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HEIGHTS::request& req, COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HEIGHTS::response& rsp) {
+  try {
+    if (req.heights.size() > BLOCK_LIST_MAX_COUNT) {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM,
+        std::string("Requested blocks count: ") + std::to_string(req.heights.size()) + " exceeded max limit of " + std::to_string(BLOCK_LIST_MAX_COUNT) };
+    }
+
+    std::vector<uint32_t> heights;
+
+    if (req.range) {
+      if (req.heights.size() != 2) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM,
+          std::string("The range is set to true but heights size is not equal to 2") };
+      }
+      uint32_t upperBound = std::min(req.heights[1], m_core.getCurrentBlockchainHeight());
+      for (size_t i = 0; i < (upperBound - req.heights[0]) + 1; i++) {
+        heights.push_back(req.heights[0] + i);
+      }
+    }
+    else {
+      heights = req.heights;
+    }
+
+    std::vector<TransactionDetails> transactions;
+
+    for (const uint32_t& height : heights) {
+      if (m_core.getCurrentBlockchainHeight() <= height) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT,
+          std::string("To big height: ") + std::to_string(height) + ", current blockchain height = " + std::to_string(m_core.getCurrentBlockchainHeight() - 1) };
+      }
+
+      Crypto::Hash block_hash = m_core.getBlockIdByHeight(height);
+      Block blk;
+      if (!m_core.getBlockByHash(block_hash, blk)) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: can't get block by height " + std::to_string(height) + '.' };
+      }
+
+      if (req.include_miner_txs) {
+        transactions.reserve(blk.transactionHashes.size() + 1);
+
+        TransactionDetails transactionDetails;
+        if (!blockchainExplorerDataBuilder.fillTransactionDetails(blk.baseTransaction, transactionDetails, blk.timestamp)) {
+          throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: can't fill miner's tx details." };
+        }
+        transactions.push_back(std::move(transactionDetails));
+      }
+      else {
+        transactions.reserve(blk.transactionHashes.size());
+      }
+
+      //bool isOrphaned = get_block_hash(blk) != block_hash;
+
+      std::list<Transaction> found;
+      std::list<Crypto::Hash> missed;
+      m_core.getTransactions(blk.transactionHashes, found, missed, false /*isOrphaned*/);
+      if (found.size() != blk.transactionHashes.size()) {
+        return false;
+      }
+
+      for (const Transaction& tx : found) {
+        TransactionDetails transactionDetails;
+        if (!blockchainExplorerDataBuilder.fillTransactionDetails(tx, transactionDetails, blk.timestamp)) {
+          throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: can't fill tx details." };
+        }
+        if (req.exclude_signatures) {
+          transactionDetails.signatures.clear();
+        }
+        transactions.push_back(std::move(transactionDetails));
+      }
+
+      for (const auto& miss_tx : missed) {
+        rsp.missed_txs.push_back(Common::podToHex(miss_tx));
+      }
+    }
+    rsp.transactions = std::move(transactions);
   }
   catch (std::system_error& e) {
     throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, e.what() };

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -100,6 +100,7 @@ private:
   bool on_get_blocks_hashes_by_timestamps(const COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS::request& req, COMMAND_RPC_GET_BLOCKS_HASHES_BY_TIMESTAMPS::response& rsp);
   bool on_get_transactions_details_by_hashes(const COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HASHES::request& req, COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HASHES::response& rsp);
   bool on_get_transaction_details_by_hash(const COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH::request& req, COMMAND_RPC_GET_TRANSACTION_DETAILS_BY_HASH::response& rsp);
+  bool on_get_transactions_details_by_heights(const COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HEIGHTS::request& req, COMMAND_RPC_GET_TRANSACTIONS_DETAILS_BY_HEIGHTS::response& rsp);
   bool on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::request& req, COMMAND_RPC_GET_TRANSACTION_HASHES_BY_PAYMENT_ID::response& rsp);
 
   // json rpc


### PR DESCRIPTION
This one is intended to use with a web/lite wallet to speed up its sync by faster-returning transactions.

Request example:
```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "gettransactionsbyheights",
  "params": {
   "heights":[1,2,3,4,5],
   "include_miner_txs":true,
   "exclude_signatures":true,
   "range":false
  }
}
```

If `range` is set to `true` then `heights` has to have two values: the beginning and the end of the range.
If `include_miner_txs` is set to `false`, it omits coinbase transactions.
If `exclude_signatures` is set to `true` it omits ring signatures in transactions, to save traffic as they are large and not needed.



