### PR TITLE
Some P2P improvements

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -175,7 +175,7 @@ const uint8_t  P2P_UPGRADE_WINDOW                            = 2;
 const uint8_t  P2P_LITE_BLOCKS_PROPOGATION_VERSION           = 3;
 
 const size_t   P2P_CONNECTION_MAX_WRITE_BUFFER_SIZE          = 64 * 1024 * 1024; // 64 MB
-const uint32_t P2P_DEFAULT_CONNECTIONS_COUNT                 = 8;
+const uint32_t P2P_DEFAULT_CONNECTIONS_COUNT                 = 12;
 const size_t   P2P_DEFAULT_ANCHOR_CONNECTIONS_COUNT          = 2;
 const size_t   P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT     = 70;
 const uint32_t P2P_DEFAULT_HANDSHAKE_INTERVAL                = 60;            // seconds

--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -181,6 +181,7 @@ const size_t   P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT     = 70;
 const uint32_t P2P_DEFAULT_HANDSHAKE_INTERVAL                = 60;            // seconds
 const uint32_t P2P_DEFAULT_PACKET_MAX_SIZE                   = 50000000;      // 50000000 bytes maximum packet size
 const uint32_t P2P_DEFAULT_PEERS_IN_HANDSHAKE                = 250;
+const uint32_t P2P_MAX_PEERS_IN_HANDSHAKE                    = 256;
 const uint32_t P2P_DEFAULT_CONNECTION_TIMEOUT                = 5000;          // 5 seconds
 const uint32_t P2P_DEFAULT_PING_CONNECTION_TIMEOUT           = 2000;          // 2 seconds
 const uint64_t P2P_DEFAULT_INVOKE_TIMEOUT                    = 60 * 2 * 1000; // 2 minutes

--- a/src/CryptoNoteCore/TransactionPool.cpp
+++ b/src/CryptoNoteCore/TransactionPool.cpp
@@ -410,6 +410,7 @@ namespace CryptoNote {
 
     total_size = 0;
     fee = 0;
+    int counter = 0;
 
     size_t max_total_size = (125 * median_size) / 100;
     max_total_size = std::min(max_total_size, maxCumulativeSize) - m_currency.minerTxBlobReservedSize();
@@ -417,6 +418,9 @@ namespace CryptoNote {
     BlockTemplate blockTemplate;
 
     for (auto i = m_fee_index.begin(); i != m_fee_index.end(); ++i) {
+      if (counter == 127)
+        break;
+
       const auto& txd = *i;
 
       size_t blockSizeLimit = (txd.fee == 0) ? median_size : max_total_size;
@@ -450,6 +454,7 @@ namespace CryptoNote {
       if (ready && blockTemplate.addTransaction(txd.id, txd.tx)) {
         total_size += txd.blobSize;
         fee += txd.fee;
+        ++counter;
         logger(DEBUGGING) << "Transaction " << txd.id << " included to block template";
       } else {
         logger(DEBUGGING) << "Transaction " << txd.id << " is failed to include to block template";

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -452,6 +452,13 @@ int CryptoNoteProtocolHandler::handle_request_get_objects(int command, NOTIFY_RE
 int CryptoNoteProtocolHandler::handle_response_get_objects(int command, NOTIFY_RESPONSE_GET_OBJECTS::request& arg, CryptoNoteConnectionContext& context) {
   logger(Logging::TRACE) << context << "NOTIFY_RESPONSE_GET_OBJECTS";
 
+  if (arg.blocks.empty())
+  {
+    logger(Logging::ERROR) << context << "sent wrong NOTIFY_HAVE_OBJECTS: no blocks, dropping connection";
+    m_p2p->drop_connection(context, true);
+    return 1;
+  }
+
   if (context.m_last_response_height > arg.current_blockchain_height) {
     logger(Logging::ERROR) << context << "sent wrong NOTIFY_HAVE_OBJECTS: arg.m_current_blockchain_height=" << arg.current_blockchain_height
       << " < m_last_response_height=" << context.m_last_response_height << ", dropping connection";

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -32,6 +32,10 @@
 #include <boost/format.hpp>
 #include "math.h"
 
+#if defined(WIN32)
+#undef ERROR
+#endif
+
 namespace {
   template <typename T>
   static bool print_as_json(const T& obj) {
@@ -63,7 +67,7 @@ DaemonCommandsHandler::DaemonCommandsHandler(CryptoNote::Core& core, CryptoNote:
   m_consoleHandler.setHandler("set_log", boost::bind(&DaemonCommandsHandler::set_log, this, boost::arg<1>()), "set_log <level> - Change current log level, <level> is a number 0-4");
   m_consoleHandler.setHandler("print_diff", boost::bind(&DaemonCommandsHandler::print_diff, this, boost::arg<1>()), "Difficulty for next block");
   m_consoleHandler.setHandler("print_ban", boost::bind(&DaemonCommandsHandler::print_ban, this, boost::arg<1>()), "Print banned nodes");
-  m_consoleHandler.setHandler("ban", boost::bind(&DaemonCommandsHandler::ban, this, boost::arg<1>()), "Ban a given <IP> for a given amount of <seconds>, ban <IP> [<seconds>]");
+  m_consoleHandler.setHandler("ban", boost::bind(&DaemonCommandsHandler::ban, this, boost::arg<1>()), "Ban a given <IP> for [<seconds>] or permanently if no duration provided, ban <IP> [<seconds>]");
   m_consoleHandler.setHandler("unban", boost::bind(&DaemonCommandsHandler::unban, this, boost::arg<1>()), "Unban a given <IP>, unban <IP>");
   m_consoleHandler.setHandler("status", boost::bind(&DaemonCommandsHandler::status, this, boost::arg<1>()), "Show daemon status");
   m_consoleHandler.setHandler("save", boost::bind(&DaemonCommandsHandler::save, this, boost::arg<1>()), "Store blockchain");
@@ -422,23 +426,24 @@ bool DaemonCommandsHandler::ban(const std::vector<std::string>& args)
   if (args.size() != 1 && args.size() != 2) return false;
   std::string addr = args[0];
   uint32_t ip;
-  time_t seconds = 0;
-  if (args.size() > 1) {
-    try {
-      seconds = std::stoi(args[1]);
-    } catch (const std::exception &e) {
-      std::cout << "Incorrect time value: " << e.what() << std::endl;
-      return false;
-    }
-    if (seconds == 0) {
-      return false;
-    }
-  } 
+  time_t seconds = std::numeric_limits<time_t>::max();
   try {
+    if (args.size() > 1) {
+      seconds = std::stoi(args[1]);
+      if (seconds == 0) {
+        logger(Logging::ERROR) << "Invalid ban duration. Should be greater than zero.";
+        return false;
+      }
+    }
     ip = Common::stringToIpAddress(addr);
-  } catch (const std::exception &e) {
-     std::cout << "Incorrect IP value: " << e.what() << std::endl;
-     return false;
+    if (!ip) {
+      logger(Logging::ERROR) << "Invalid IP address: " << addr;
+      return false;
+    }
+  }
+  catch (const std::exception &e) {
+    logger(Logging::ERROR) << "Failed to parse ban parameters: " << e.what();
+    return false;
   }
   return m_srv.ban_host(ip, seconds);
 }
@@ -447,11 +452,9 @@ bool DaemonCommandsHandler::unban(const std::vector<std::string>& args)
 {
   if (args.size() != 1) return false;
   std::string addr = args[0];
-  uint32_t ip;
-  try {
-    ip = Common::stringToIpAddress(addr);
-  } catch (const std::exception &e) {
-    std::cout << "Incorrect IP value: " << e.what() << std::endl;
+  uint32_t ip = Common::stringToIpAddress(addr);
+  if (!ip) {
+    logger(Logging::ERROR) << "Invalid IP address: " << addr;
     return false;
   }
   return m_srv.unban_host(ip);

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1509,7 +1509,12 @@ namespace CryptoNote
   bool NodeServer::gray_peerlist_housekeeping() {
     PeerlistEntry pe = boost::value_initialized<PeerlistEntry>();
     
-    size_t random_index = Random::randomValue<size_t>() % m_peerlist.get_gray_peers_count();
+    size_t gray_peers_count = m_peerlist.get_gray_peers_count();
+
+    if (!gray_peers_count)
+      return false;
+
+    size_t random_index = Random::randomValue<size_t>() % gray_peers_count;
     if (!m_peerlist.get_gray_peer_by_index(pe, random_index))
       return false;
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -463,48 +463,6 @@ namespace CryptoNote
   }
   //-----------------------------------------------------------------------------------
 
-  bool NodeServer::handle_command_line(const boost::program_options::variables_map& vm)
-  {
-    logger(INFO) << "Handling NodeServer config...";
-
-    m_bind_ip = command_line::get_arg(vm, CryptoNote::arg_p2p_bind_ip);
-    m_port = command_line::get_arg(vm, CryptoNote::arg_p2p_bind_port);
-    m_external_port = command_line::get_arg(vm, CryptoNote::arg_p2p_external_port);
-    m_allow_local_ip = command_line::get_arg(vm, CryptoNote::arg_p2p_allow_local_ip);
-
-    if (command_line::has_arg(vm, CryptoNote::arg_p2p_add_peer))
-    {       
-      std::vector<std::string> peers = command_line::get_arg(vm, CryptoNote::arg_p2p_add_peer);
-      for(const std::string& pr_str: peers)
-      {
-        PeerlistEntry pe = boost::value_initialized<PeerlistEntry>();
-        pe.id = Random::randomValue<size_t>();
-        bool r = parse_peer_from_string(pe.adr, pr_str);
-        if (!(r)) { logger(ERROR, BRIGHT_RED) << "Failed to parse address from string: " << pr_str; return false; }
-        m_command_line_peers.push_back(pe);
-      }
-    }
-
-    if (command_line::has_arg(vm, CryptoNote::arg_p2p_add_exclusive_node)) {
-      if (!parse_peers_and_add_to_container(vm, CryptoNote::arg_p2p_add_exclusive_node, m_exclusive_peers))
-        return false;
-    }
-    if (command_line::has_arg(vm, CryptoNote::arg_p2p_add_priority_node)) {
-      if (!parse_peers_and_add_to_container(vm, CryptoNote::arg_p2p_add_priority_node, m_priority_peers))
-        return false;
-    }
-    if (command_line::has_arg(vm, CryptoNote::arg_p2p_seed_node)) {
-      if (!parse_peers_and_add_to_container(vm, CryptoNote::arg_p2p_seed_node, m_seed_nodes))
-        return false;
-    }
-
-    if (command_line::has_arg(vm, CryptoNote::arg_p2p_hide_my_port)) {
-      m_hide_my_port = true;
-    }
-
-    return true;
-  }
-
   bool NodeServer::handleConfig(const NetNodeConfig& config) {
     m_bind_ip = config.getBindIp();
     m_port = std::to_string(config.getBindPort());

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -132,7 +132,7 @@ namespace CryptoNote
     const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node          = {"seed-node", "Connect to a node to retrieve peer addresses, and disconnect"};
     const command_line::arg_descriptor<bool> arg_p2p_hide_my_port                            = {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
 
-    std::string print_peerlist_to_string(const std::list<PeerlistEntry>& pl) {
+    std::string print_peerlist_to_string(const std::vector<PeerlistEntry>& pl) {
       time_t now_time = 0;
       time(&now_time);
       std::stringstream ss;
@@ -1158,7 +1158,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
-  bool NodeServer::fix_time_delta(std::list<PeerlistEntry>& local_peerlist, time_t local_time, int64_t& delta)
+  bool NodeServer::fix_time_delta(std::vector<PeerlistEntry>& local_peerlist, time_t local_time, int64_t& delta)
   {
     //fix time delta
     time_t now = 0;
@@ -1179,7 +1179,7 @@ namespace CryptoNote
 
   //-----------------------------------------------------------------------------------
  
-  bool NodeServer::handle_remote_peerlist(const std::list<PeerlistEntry>& peerlist, time_t local_time, const CryptoNoteConnectionContext& context)
+  bool NodeServer::handle_remote_peerlist(const std::vector<PeerlistEntry>& peerlist, time_t local_time, const CryptoNoteConnectionContext& context)
   {
     if (peerlist.size() > P2P_MAX_PEERS_IN_HANDSHAKE)
     {
@@ -1188,7 +1188,7 @@ namespace CryptoNote
     }
     
     int64_t delta = 0;
-    std::list<PeerlistEntry> peerlist_ = peerlist;
+    std::vector<PeerlistEntry> peerlist_ = peerlist;
     if(!fix_time_delta(peerlist_, local_time, delta))
       return false;
     //logger(Logging::TRACE) << context << "REMOTE PEERLIST: TIME_DELTA: " << delta << ", remote peerlist size=" << peerlist_.size();
@@ -1457,8 +1457,8 @@ namespace CryptoNote
   bool NodeServer::log_peerlist()
   {
     std::list<AnchorPeerlistEntry> pl_anchor;
-    std::list<PeerlistEntry> pl_wite;
-    std::list<PeerlistEntry> pl_gray;
+    std::vector<PeerlistEntry> pl_wite;
+    std::vector<PeerlistEntry> pl_gray;
     m_peerlist.get_peerlist_full(pl_anchor, pl_gray, pl_wite);
     logger(INFO) << ENDL << "Peerlist anchor:" << ENDL << print_peerlist_to_string(pl_anchor) << ENDL 
                          << "Peerlist white:" << ENDL << print_peerlist_to_string(pl_wite) << ENDL 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -247,9 +247,11 @@ namespace CryptoNote
     m_timeoutTimer(m_dispatcher),
     m_stop(false),
     // intervals
-    // m_peer_handshake_idle_maker_interval(CryptoNote::P2P_DEFAULT_HANDSHAKE_INTERVAL),
+    m_peer_handshake_idle_maker_interval(CryptoNote::P2P_DEFAULT_HANDSHAKE_INTERVAL),
     m_connections_maker_interval(1),
-    m_peerlist_store_interval(60*30, false) {
+    m_peerlist_store_interval(60*30, false),
+    m_gray_peerlist_housekeeping_interval(CryptoNote::P2P_DEFAULT_HANDSHAKE_INTERVAL)
+  {
   }
 
   void NodeServer::serialize(ISerializer& s) {
@@ -992,9 +994,9 @@ namespace CryptoNote
       if(is_peer_used(pe))
         continue;
 
-	  if (!is_remote_host_allowed(pe.adr.ip)) {
-		  continue;
-	  }
+      if (!is_remote_host_allowed(pe.adr.ip)) {
+        continue;
+      }
 
       logger(DEBUGGING) << "Selected peer: " << pe.id << " " << pe.adr << " [peer_list=" << (use_white_list ? white : gray)
                     << "] last_seen: " << (pe.last_seen ? Common::timeIntervalToString(time(NULL) - pe.last_seen) : "never");
@@ -1151,6 +1153,7 @@ namespace CryptoNote
     try {
       m_connections_maker_interval.call(std::bind(&NodeServer::connections_maker, this));
       m_peerlist_store_interval.call(std::bind(&NodeServer::store_config, this));
+      m_gray_peerlist_housekeeping_interval.call(std::bind(&NodeServer::gray_peerlist_housekeeping, this));
     } catch (std::exception& e) {
       logger(DEBUGGING) << "exception in idle_worker: " << e.what();
     }
@@ -1529,6 +1532,25 @@ namespace CryptoNote
       if (!is_addr_connected(na)) {
         try_to_connect_and_handshake_with_new_peer(na);
       }
+    }
+
+    return true;
+  }
+
+  bool NodeServer::gray_peerlist_housekeeping() {
+    PeerlistEntry pe = boost::value_initialized<PeerlistEntry>();
+    
+    size_t random_index = Random::randomValue<size_t>() % m_peerlist.get_gray_peers_count();
+    if (!m_peerlist.get_gray_peer_by_index(pe, random_index))
+      return false;
+
+    if (!try_to_connect_and_handshake_with_new_peer(pe.adr, false, 0, gray, pe.last_seen)) {
+      m_peerlist.remove_from_peer_gray(pe);
+      logger(DEBUGGING) << "PEER EVICTED FROM GRAY PEER LIST IP address: " << Common::ipAddressToString(pe.adr.ip) << " Peer ID: " << std::hex << pe.id;
+    } else {
+      pe.last_seen = time(nullptr);
+      m_peerlist.append_with_peer_white(pe);
+      logger(DEBUGGING) << "PEER PROMOTED TO WHITE PEER LIST IP address: " << Common::ipAddressToString(pe.adr.ip) << " Peer ID: " << std::hex << pe.id;
     }
 
     return true;

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1423,8 +1423,12 @@ namespace CryptoNote
   
   bool NodeServer::log_banlist()
   {
-	  logger(INFO) << "Banned nodes:" << ENDL << print_banlist_to_string(m_blocked_hosts) << ENDL;
-	  return true;
+    if (m_blocked_hosts.empty())
+      logger(INFO) << "No banned nodes";
+    else
+     logger(INFO) << "Banned nodes:" << ENDL << print_banlist_to_string(m_blocked_hosts) << ENDL;
+
+    return true;
   }
   //-----------------------------------------------------------------------------------
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1181,6 +1181,12 @@ namespace CryptoNote
  
   bool NodeServer::handle_remote_peerlist(const std::list<PeerlistEntry>& peerlist, time_t local_time, const CryptoNoteConnectionContext& context)
   {
+    if (peerlist.size() > P2P_MAX_PEERS_IN_HANDSHAKE)
+    {
+      logger(WARNING) << "peer sent " << peerlist.size() << " peers, considered spamming";
+      return false;
+    }
+    
     int64_t delta = 0;
     std::list<PeerlistEntry> peerlist_ = peerlist;
     if(!fix_time_delta(peerlist_, local_time, delta))
@@ -1425,7 +1431,7 @@ namespace CryptoNote
           pe.id = peer_id_l;
           m_peerlist.append_with_peer_white(pe);
 
-          logger(Logging::TRACE) << context << "BACK PING SUCCESS, " << Common::ipAddressToString(context.m_remote_ip) << ":" << port_l << " added to whitelist";
+          logger(Logging::DEBUGGING) << context << "BACK PING SUCCESS, " << Common::ipAddressToString(context.m_remote_ip) << ":" << port_l << " added to whitelist";
       }
     }
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -994,10 +994,9 @@ namespace CryptoNote
       if(is_peer_used(pe))
         continue;
 
-      if (!is_remote_host_allowed(pe.adr.ip)) {
+      if (!is_remote_host_allowed(pe.adr.ip))
         continue;
-      }
-
+      
       logger(DEBUGGING) << "Selected peer: " << pe.id << " " << pe.adr << " [peer_list=" << (use_white_list ? white : gray)
                     << "] last_seen: " << (pe.last_seen ? Common::timeIntervalToString(time(NULL) - pe.last_seen) : "never");
       
@@ -1283,7 +1282,7 @@ namespace CryptoNote
 
     m_peerlist.get_peerlist_full(rsp.local_peerlist_gray, rsp.local_peerlist_white);
     rsp.my_id = m_config.m_peer_id;
-    rsp.local_time = time(NULL);
+    rsp.local_time = time(nullptr);
     return 1;
   }
   //-----------------------------------------------------------------------------------
@@ -1375,7 +1374,7 @@ namespace CryptoNote
     }
 
     //fill response
-    rsp.local_time = time(NULL);
+    rsp.local_time = time(nullptr);
 
     std::vector<PeerlistEntry> local_peerlist_new;
     m_peerlist.get_peerlist_head(local_peerlist_new);

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -61,6 +61,8 @@
 #include "Serialization/BinaryOutputStreamSerializer.h"
 #include "Serialization/SerializationOverloads.h"
 
+#include "NetNodeConfig.h"
+
 using namespace Common;
 using namespace Logging;
 using namespace CryptoNote;
@@ -123,17 +125,6 @@ namespace CryptoNote
 {
   namespace
   {
-    const command_line::arg_descriptor<std::string> arg_p2p_bind_ip                          = {"p2p-bind-ip", "Interface for p2p network protocol", "0.0.0.0"};
-    const command_line::arg_descriptor<std::string> arg_p2p_bind_port                        = {"p2p-bind-port", "Port for p2p network protocol", std::to_string(CryptoNote::P2P_DEFAULT_PORT)};
-    const command_line::arg_descriptor<uint32_t>    arg_p2p_external_port                    = {"p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0};
-    const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip                   = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes"};
-    const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer           = {"add-peer", "Manually add peer to local peerlist"};
-    const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_priority_node  = {"add-priority-node", "Specify list of peers to connect to and attempt to keep the connection open"};
-    const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_exclusive_node = {"add-exclusive-node", "Specify list of peers to connect to only."
-                                                                                                " If this option is given the options add-priority-node and seed-node are ignored"};
-    const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node          = {"seed-node", "Connect to a node to retrieve peer addresses, and disconnect"};
-    const command_line::arg_descriptor<bool> arg_p2p_hide_my_port                            = {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
-
     std::string print_peerlist_to_string(const std::vector<PeerlistEntry>& pl) {
       time_t now_time = 0;
       time(&now_time);
@@ -302,20 +293,6 @@ namespace CryptoNote
 
 #undef INVOKE_HANDLER
 
-  //-----------------------------------------------------------------------------------
-  
-  void NodeServer::init_options(boost::program_options::options_description& desc)
-  {
-    command_line::add_arg(desc, arg_p2p_bind_ip);
-    command_line::add_arg(desc, arg_p2p_bind_port);
-    command_line::add_arg(desc, arg_p2p_external_port);
-    command_line::add_arg(desc, arg_p2p_allow_local_ip);
-    command_line::add_arg(desc, arg_p2p_add_peer);
-    command_line::add_arg(desc, arg_p2p_add_priority_node);
-    command_line::add_arg(desc, arg_p2p_add_exclusive_node);
-    command_line::add_arg(desc, arg_p2p_seed_node);    
-    command_line::add_arg(desc, arg_p2p_hide_my_port);
-  }
   //-----------------------------------------------------------------------------------
   
   bool NodeServer::init_config() {
@@ -488,14 +465,16 @@ namespace CryptoNote
 
   bool NodeServer::handle_command_line(const boost::program_options::variables_map& vm)
   {
-    m_bind_ip = command_line::get_arg(vm, arg_p2p_bind_ip);
-    m_port = command_line::get_arg(vm, arg_p2p_bind_port);
-    m_external_port = command_line::get_arg(vm, arg_p2p_external_port);
-    m_allow_local_ip = command_line::get_arg(vm, arg_p2p_allow_local_ip);
+    logger(INFO) << "Handling NodeServer config...";
 
-    if (command_line::has_arg(vm, arg_p2p_add_peer))
+    m_bind_ip = command_line::get_arg(vm, CryptoNote::arg_p2p_bind_ip);
+    m_port = command_line::get_arg(vm, CryptoNote::arg_p2p_bind_port);
+    m_external_port = command_line::get_arg(vm, CryptoNote::arg_p2p_external_port);
+    m_allow_local_ip = command_line::get_arg(vm, CryptoNote::arg_p2p_allow_local_ip);
+
+    if (command_line::has_arg(vm, CryptoNote::arg_p2p_add_peer))
     {       
-      std::vector<std::string> peers = command_line::get_arg(vm, arg_p2p_add_peer);
+      std::vector<std::string> peers = command_line::get_arg(vm, CryptoNote::arg_p2p_add_peer);
       for(const std::string& pr_str: peers)
       {
         PeerlistEntry pe = boost::value_initialized<PeerlistEntry>();
@@ -506,20 +485,20 @@ namespace CryptoNote
       }
     }
 
-    if (command_line::has_arg(vm,arg_p2p_add_exclusive_node)) {
-      if (!parse_peers_and_add_to_container(vm, arg_p2p_add_exclusive_node, m_exclusive_peers))
+    if (command_line::has_arg(vm, CryptoNote::arg_p2p_add_exclusive_node)) {
+      if (!parse_peers_and_add_to_container(vm, CryptoNote::arg_p2p_add_exclusive_node, m_exclusive_peers))
         return false;
     }
-    if (command_line::has_arg(vm, arg_p2p_add_priority_node)) {
-      if (!parse_peers_and_add_to_container(vm, arg_p2p_add_priority_node, m_priority_peers))
+    if (command_line::has_arg(vm, CryptoNote::arg_p2p_add_priority_node)) {
+      if (!parse_peers_and_add_to_container(vm, CryptoNote::arg_p2p_add_priority_node, m_priority_peers))
         return false;
     }
-    if (command_line::has_arg(vm, arg_p2p_seed_node)) {
-      if (!parse_peers_and_add_to_container(vm, arg_p2p_seed_node, m_seed_nodes))
+    if (command_line::has_arg(vm, CryptoNote::arg_p2p_seed_node)) {
+      if (!parse_peers_and_add_to_container(vm, CryptoNote::arg_p2p_seed_node, m_seed_nodes))
         return false;
     }
 
-    if (command_line::has_arg(vm, arg_p2p_hide_my_port)) {
+    if (command_line::has_arg(vm, CryptoNote::arg_p2p_hide_my_port)) {
       m_hide_my_port = true;
     }
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1168,9 +1168,9 @@ namespace CryptoNote
     time(&now);
     delta = now - local_time;
 
-    BOOST_FOREACH(PeerlistEntry& be, local_peerlist)
+    for (PeerlistEntry& be : local_peerlist)
     {
-      if(be.last_seen > uint64_t(local_time))
+      if (be.last_seen > uint64_t(local_time))
       {
         logger(DEBUGGING) << "FOUND FUTURE peerlist for entry " << be.adr << " last_seen: " << be.last_seen << ", local_time (on remote node):" << local_time;
         return false;

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1376,7 +1376,18 @@ namespace CryptoNote
 
     //fill response
     rsp.local_time = time(NULL);
-    m_peerlist.get_peerlist_head(rsp.local_peerlist);
+
+    std::vector<PeerlistEntry> local_peerlist_new;
+    m_peerlist.get_peerlist_head(local_peerlist_new);
+    //only include out peers we did not already send
+    rsp.local_peerlist.reserve(local_peerlist_new.size());
+    for (auto &pe : local_peerlist_new)
+    {
+      if (!context.sent_addresses.insert(pe.adr).second)
+        continue;
+      rsp.local_peerlist.push_back(std::move(pe));
+    }
+    
     m_payload_handler.get_payload_sync_data(rsp.payload_data);
     logger(Logging::TRACE) << context << "COMMAND_TIMED_SYNC";
     return 1;
@@ -1440,6 +1451,8 @@ namespace CryptoNote
 
     //fill response
     m_peerlist.get_peerlist_head(rsp.local_peerlist);
+    for (const auto &e : rsp.local_peerlist)
+      context.sent_addresses.insert(e.adr);
     get_local_node_data(rsp.node_data);
     m_payload_handler.get_payload_sync_data(rsp.payload_data);
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -65,6 +65,8 @@ using namespace Common;
 using namespace Logging;
 using namespace CryptoNote;
 
+const int64_t LAST_SEEN_EVICT_THRESHOLD = 3600 * 24 * 10; // 10 days before removing from gray list
+
 namespace {
 
 size_t get_random_index_with_fixed_probability(size_t max_index) {
@@ -1557,8 +1559,11 @@ namespace CryptoNote
       return false;
 
     if (!try_to_connect_and_handshake_with_new_peer(pe.adr, false, 0, gray, pe.last_seen)) {
-      m_peerlist.remove_from_peer_gray(pe);
-      logger(DEBUGGING) << "PEER EVICTED FROM GRAY PEER LIST IP address: " << Common::ipAddressToString(pe.adr.ip) << " Peer ID: " << std::hex << pe.id;
+      time_t now = time(nullptr);
+      if (now - pe.last_seen >= LAST_SEEN_EVICT_THRESHOLD) {
+        m_peerlist.remove_from_peer_gray(pe);
+        logger(DEBUGGING) << "PEER EVICTED FROM GRAY PEER LIST IP address: " << Common::ipAddressToString(pe.adr.ip) << " Peer ID: " << std::hex << pe.id;
+      }
     } else {
       pe.last_seen = time(nullptr);
       m_peerlist.append_with_peer_white(pe);

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -374,7 +374,15 @@ namespace CryptoNote
   //-----------------------------------------------------------------------------------
   bool NodeServer::block_host(const uint32_t address_ip, time_t seconds)
   {
-    m_blocked_hosts[address_ip] = time(nullptr) + seconds;
+    const time_t now = time(nullptr);
+
+    time_t limit;
+    if (now > std::numeric_limits<time_t>::max() - seconds)
+      limit = std::numeric_limits<time_t>::max();
+    else
+      limit = now + seconds;
+
+    m_blocked_hosts[address_ip] = limit;
     // drop any connection to that IP
     forEachConnection([&](P2pConnectionContext& context) {
       if (context.m_remote_ip == address_ip) {
@@ -482,6 +490,12 @@ namespace CryptoNote
     std::copy(seedNodes.begin(), seedNodes.end(), std::back_inserter(m_seed_nodes));
 
     m_hide_my_port = config.getHideMyPort();
+
+    std::vector<uint32_t> ban_list = config.getBanList();
+    for (const auto& a : ban_list) {
+      block_host(a, std::numeric_limits<time_t>::max());
+    }
+
     return true;
   }
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1376,11 +1376,11 @@ namespace CryptoNote
     //fill response
     rsp.local_time = time(nullptr);
 
-    std::vector<PeerlistEntry> local_peerlist_new;
-    m_peerlist.get_peerlist_head(local_peerlist_new);
+    std::vector<PeerlistEntry> local_peerlist;
+    m_peerlist.get_peerlist_head(local_peerlist);
     //only include out peers we did not already send
-    rsp.local_peerlist.reserve(local_peerlist_new.size());
-    for (auto &pe : local_peerlist_new)
+    rsp.local_peerlist.reserve(local_peerlist.size());
+    for (auto &pe : local_peerlist)
     {
       if (!context.sent_addresses.insert(pe.adr).second)
         continue;

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -89,6 +89,7 @@ namespace CryptoNote
     System::Context<void>* context;
     PeerIdType peerId;
     System::TcpConnection connection;
+    std::set<NetworkAddress> sent_addresses;
 
     P2pConnectionContext(System::Dispatcher& dispatcher, Logging::ILogger& log, System::TcpConnection&& conn) :
       context(nullptr),

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -129,8 +129,6 @@ namespace CryptoNote
   {
   public:
 
-    static void init_options(boost::program_options::options_description& desc);
-
     NodeServer(System::Dispatcher& dispatcher, CryptoNote::CryptoNoteProtocolHandler& payload_handler, Logging::ILogger& log);
 
     bool run();

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -202,10 +202,10 @@ namespace CryptoNote
     bool handleConfig(const NetNodeConfig& config);
     bool append_net_address(std::vector<NetworkAddress>& nodes, const std::string& addr);
     bool idle_worker();
-    bool handle_remote_peerlist(const std::list<PeerlistEntry>& peerlist, time_t local_time, const CryptoNoteConnectionContext& context);
+    bool handle_remote_peerlist(const std::vector<PeerlistEntry>& peerlist, time_t local_time, const CryptoNoteConnectionContext& context);
     bool get_local_node_data(basic_node_data& node_data);
 
-    bool fix_time_delta(std::list<PeerlistEntry>& local_peerlist, time_t local_time, int64_t& delta);
+    bool fix_time_delta(std::vector<PeerlistEntry>& local_peerlist, time_t local_time, int64_t& delta);
 
     bool connections_maker();
     bool make_new_connection_from_peerlist(bool use_white_list);
@@ -285,7 +285,7 @@ namespace CryptoNote
     std::vector<NetworkAddress> m_priority_peers;
     std::vector<NetworkAddress> m_exclusive_peers;
     std::vector<NetworkAddress> m_seed_nodes;
-    std::list<PeerlistEntry> m_command_line_peers;
+    std::vector<PeerlistEntry> m_command_line_peers;
     uint64_t m_peer_livetime;
     boost::uuids::uuid m_network_id;
     std::map<uint32_t, time_t> m_blocked_hosts;

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -223,6 +223,8 @@ namespace CryptoNote
     bool parse_peers_and_add_to_container(const boost::program_options::variables_map& vm, 
       const command_line::arg_descriptor<std::vector<std::string> > & arg, std::vector<NetworkAddress>& container);
 
+    bool gray_peerlist_housekeeping();
+
     //debug functions
     std::string print_connections_container();
 
@@ -272,9 +274,10 @@ namespace CryptoNote
     CryptoNoteProtocolHandler& m_payload_handler;
     PeerlistManager m_peerlist;
 
-    // OnceInInterval m_peer_handshake_idle_maker_interval;
+    OnceInInterval m_peer_handshake_idle_maker_interval;
     OnceInInterval m_connections_maker_interval;
     OnceInInterval m_peerlist_store_interval;
+    OnceInInterval m_gray_peerlist_housekeeping_interval;
     System::Timer m_timedSyncTimer;
 
     std::string m_bind_ip;

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -195,7 +195,6 @@ namespace CryptoNote
     bool add_host_fail(const uint32_t address_ip);
     bool block_host(const uint32_t address_ip, time_t seconds = P2P_IP_BLOCKTIME);
     bool unblock_host(const uint32_t address_ip);
-    bool handle_command_line(const boost::program_options::variables_map& vm);
     bool is_remote_host_allowed(const uint32_t address_ip);
     bool is_addr_recently_failed(const uint32_t address_ip);
     bool handleConfig(const NetNodeConfig& config);

--- a/src/P2p/NetNodeConfig.cpp
+++ b/src/P2p/NetNodeConfig.cpp
@@ -20,25 +20,12 @@
 #include <boost/utility/value_init.hpp>
 
 #include <Common/Util.h>
-#include "Common/CommandLine.h"
 #include "Common/StringTools.h"
 #include "crypto/crypto.h"
 #include "crypto/random.h"
-#include "CryptoNoteConfig.h"
 
 namespace CryptoNote {
 namespace {
-
-const command_line::arg_descriptor<std::string> arg_p2p_bind_ip        = {"p2p-bind-ip", "Interface for p2p network protocol", "0.0.0.0"};
-const command_line::arg_descriptor<uint16_t>    arg_p2p_bind_port      = {"p2p-bind-port", "Port for p2p network protocol", P2P_DEFAULT_PORT};
-const command_line::arg_descriptor<uint16_t>    arg_p2p_external_port = { "p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0 };
-const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip = {"allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes"};
-const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer   = {"add-peer", "Manually add peer to local peerlist"};
-const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_priority_node   = {"add-priority-node", "Specify list of peers to connect to and attempt to keep the connection open"};
-const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_exclusive_node   = {"add-exclusive-node", "Specify list of peers to connect to only."
-      " If this option is given the options add-priority-node and seed-node are ignored"};
-const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node   = {"seed-node", "Connect to a node to retrieve peer addresses, and disconnect"};
-const command_line::arg_descriptor<bool> arg_p2p_hide_my_port   =    {"hide-my-port", "Do not announce yourself as peerlist candidate", false, true};
 
 bool parsePeerFromString(NetworkAddress& pe, const std::string& node_addr) {
   return Common::parseIpAddressAndPort(pe.ip, pe.port, node_addr);

--- a/src/P2p/NetNodeConfig.cpp
+++ b/src/P2p/NetNodeConfig.cpp
@@ -17,6 +17,7 @@
 
 #include "NetNodeConfig.h"
 
+#include <fstream>
 #include <boost/utility/value_init.hpp>
 
 #include <Common/Util.h>
@@ -58,6 +59,7 @@ void NetNodeConfig::initOptions(boost::program_options::options_description& des
   command_line::add_arg(desc, arg_p2p_add_priority_node);
   command_line::add_arg(desc, arg_p2p_add_exclusive_node);
   command_line::add_arg(desc, arg_p2p_seed_node);
+  command_line::add_arg(desc, arg_ban_list);
   command_line::add_arg(desc, arg_p2p_hide_my_port);
 }
 
@@ -127,6 +129,25 @@ bool NetNodeConfig::init(const boost::program_options::variables_map& vm)
     hideMyPort = true;
   }
 
+  if (command_line::has_arg(vm, CryptoNote::arg_ban_list)) {
+    const std::string ban_list_file = command_line::get_arg(vm, CryptoNote::arg_ban_list);
+
+    std::ifstream file(ban_list_file);
+    if (!file) {
+      throw std::runtime_error("Failed to read ban list file " + ban_list_file);
+      return false;
+    }
+
+    for (std::string line; std::getline(file, line); )
+    {
+      uint32_t parsed_addr = Common::stringToIpAddress(line);
+      if (!parsed_addr) {
+        continue; // silently skip because no logging here
+      }
+      banList.push_back(parsed_addr);
+    }
+  }
+
   return true;
 }
 
@@ -176,6 +197,10 @@ std::vector<NetworkAddress> NetNodeConfig::getExclusiveNodes() const {
 
 std::vector<NetworkAddress> NetNodeConfig::getSeedNodes() const {
   return seedNodes;
+}
+
+std::vector<uint32_t> NetNodeConfig::getBanList() const {
+  return banList;
 }
 
 bool NetNodeConfig::getHideMyPort() const {

--- a/src/P2p/NetNodeConfig.h
+++ b/src/P2p/NetNodeConfig.h
@@ -23,8 +23,21 @@
 
 #include <boost/program_options.hpp>
 #include "P2pProtocolTypes.h"
+#include "Common/CommandLine.h"
+#include "CryptoNoteConfig.h"
 
 namespace CryptoNote {
+
+  const command_line::arg_descriptor<std::string> arg_p2p_bind_ip                          = { "p2p-bind-ip", "Interface for p2p network protocol", "0.0.0.0" };
+  const command_line::arg_descriptor<uint16_t>    arg_p2p_bind_port                        = { "p2p-bind-port", "Port for p2p network protocol", P2P_DEFAULT_PORT };
+  const command_line::arg_descriptor<uint16_t>    arg_p2p_external_port                    = { "p2p-external-port", "External port for p2p network protocol (if port forwarding used with NAT)", 0 };
+  const command_line::arg_descriptor<bool>        arg_p2p_allow_local_ip                   = { "allow-local-ip", "Allow local ip add to peer list, mostly in debug purposes" };
+  const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_peer           = { "add-peer", "Manually add peer to local peerlist" };
+  const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_priority_node  = { "add-priority-node", "Specify list of peers to connect to and attempt to keep the connection open" };
+  const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_exclusive_node = { "add-exclusive-node", "Specify list of peers to connect to only."
+                                                                                               " If this option is given the options add-priority-node and seed-node are ignored" };
+  const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node          = { "seed-node", "Connect to a node to retrieve peer addresses, and disconnect" };
+  const command_line::arg_descriptor<bool> arg_p2p_hide_my_port                            = { "hide-my-port", "Do not announce yourself as peerlist candidate", false, true };
 
 class NetNodeConfig {
 public:

--- a/src/P2p/NetNodeConfig.h
+++ b/src/P2p/NetNodeConfig.h
@@ -37,6 +37,7 @@ namespace CryptoNote {
   const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_add_exclusive_node = { "add-exclusive-node", "Specify list of peers to connect to only."
                                                                                                " If this option is given the options add-priority-node and seed-node are ignored" };
   const command_line::arg_descriptor<std::vector<std::string> > arg_p2p_seed_node          = { "seed-node", "Connect to a node to retrieve peer addresses, and disconnect" };
+  const command_line::arg_descriptor<std::string> arg_ban_list                             = { "ban-list", "Specify ban list file, one IP address per line", "", true };
   const command_line::arg_descriptor<bool> arg_p2p_hide_my_port                            = { "hide-my-port", "Do not announce yourself as peerlist candidate", false, true };
 
 class NetNodeConfig {
@@ -55,6 +56,7 @@ public:
   std::vector<NetworkAddress> getPriorityNodes() const;
   std::vector<NetworkAddress> getExclusiveNodes() const;
   std::vector<NetworkAddress> getSeedNodes() const;
+  std::vector<uint32_t> getBanList() const;
   bool getHideMyPort() const;
   std::string getConfigFolder() const;
 
@@ -80,6 +82,7 @@ private:
   std::vector<NetworkAddress> priorityNodes;
   std::vector<NetworkAddress> exclusiveNodes;
   std::vector<NetworkAddress> seedNodes;
+  std::vector<uint32_t> banList;
   bool hideMyPort;
   std::string configFolder;
   std::string p2pStateFilename;

--- a/src/P2p/P2pProtocolDefinitions.h
+++ b/src/P2p/P2pProtocolDefinitions.h
@@ -109,7 +109,7 @@ namespace CryptoNote
     {
       basic_node_data node_data;
       CORE_SYNC_DATA payload_data;
-      std::list<PeerlistEntry> local_peerlist; 
+      std::vector<PeerlistEntry> local_peerlist; 
 
       void serialize(ISerializer& s) {
         KV_MEMBER(node_data)
@@ -141,7 +141,7 @@ namespace CryptoNote
     {
       uint64_t local_time;
       CORE_SYNC_DATA payload_data;
-      std::list<PeerlistEntry> local_peerlist;
+      std::vector<PeerlistEntry> local_peerlist;
 
       void serialize(ISerializer& s) {
         KV_MEMBER(local_time)
@@ -259,8 +259,8 @@ namespace CryptoNote
 
     struct response
     {
-      std::list<PeerlistEntry> local_peerlist_white;
-      std::list<PeerlistEntry> local_peerlist_gray;
+      std::vector<PeerlistEntry> local_peerlist_white;
+      std::vector<PeerlistEntry> local_peerlist_gray;
       std::list<connection_entry> connections_list;
       PeerIdType my_id;
       uint64_t local_time;

--- a/src/P2p/PeerListManager.cpp
+++ b/src/P2p/PeerListManager.cpp
@@ -21,8 +21,8 @@
 
 #include <time.h>
 #include <boost/foreach.hpp>
+#include <crypto/random.h>
 #include <System/Ipv4Address.h>
-
 #include "Serialization/SerializationOverloads.h"
 
 using namespace CryptoNote;
@@ -170,14 +170,19 @@ bool PeerlistManager::get_peerlist_head(std::vector<PeerlistEntry>& bs_head, uin
 
   BOOST_REVERSE_FOREACH(const peers_indexed::value_type& vl, by_time_index)
   {
-    if (cnt++ > depth)
-      break;
+    //if (cnt++ > depth)
+    //  break;
 
     if (!vl.last_seen)
       continue;
 
     bs_head.push_back(vl);
   }
+
+  std::shuffle(bs_head.begin(), bs_head.end(), Random::generator());
+  if (bs_head.size() > depth)
+      bs_head.resize(depth);
+
   return true;
 }
 //--------------------------------------------------------------------------------------------------

--- a/src/P2p/PeerListManager.cpp
+++ b/src/P2p/PeerListManager.cpp
@@ -122,7 +122,7 @@ void PeerlistManager::trim_gray_peerlist() {
 }
 
 //--------------------------------------------------------------------------------------------------
-bool PeerlistManager::merge_peerlist(const std::list<PeerlistEntry>& outer_bs)
+bool PeerlistManager::merge_peerlist(const std::vector<PeerlistEntry>& outer_bs)
 { 
   for(const PeerlistEntry& be : outer_bs) {
     append_with_peer_gray(be);
@@ -163,7 +163,7 @@ bool PeerlistManager::is_ip_allowed(uint32_t ip) const
 }
 //--------------------------------------------------------------------------------------------------
 
-bool PeerlistManager::get_peerlist_head(std::list<PeerlistEntry>& bs_head, uint32_t depth) const
+bool PeerlistManager::get_peerlist_head(std::vector<PeerlistEntry>& bs_head, uint32_t depth) const
 {
   const peers_indexed::index<by_time>::type& by_time_index = m_peers_white.get<by_time>();
   uint32_t cnt = 0;
@@ -182,7 +182,7 @@ bool PeerlistManager::get_peerlist_head(std::list<PeerlistEntry>& bs_head, uint3
 }
 //--------------------------------------------------------------------------------------------------
 
-bool PeerlistManager::get_peerlist_full(std::list<AnchorPeerlistEntry>& pl_anchor, std::list<PeerlistEntry>& pl_gray, std::list<PeerlistEntry>& pl_white) const
+bool PeerlistManager::get_peerlist_full(std::list<AnchorPeerlistEntry>& pl_anchor, std::vector<PeerlistEntry>& pl_gray, std::vector<PeerlistEntry>& pl_white) const
 {
   const anchor_peers_indexed::index<by_time>::type& by_time_index_an = m_peers_anchor.get<by_time>();
   const peers_indexed::index<by_time>::type& by_time_index_gr = m_peers_gray.get<by_time>();

--- a/src/P2p/PeerListManager.cpp
+++ b/src/P2p/PeerListManager.cpp
@@ -331,10 +331,29 @@ bool PeerlistManager::remove_from_peer_anchor(const NetworkAddress& addr)
     if (iterator != m_peers_anchor.get<by_addr>().end()) {
       m_peers_anchor.erase(iterator);
     }
+
     return true;
   }
   catch (std::exception&) {
   }
+
+  return false;
+}
+//--------------------------------------------------------------------------------------------------
+
+bool PeerlistManager::remove_from_peer_gray(PeerlistEntry& p)
+{
+  try {
+    auto iterator = m_peers_gray.get<by_addr>().find(p.adr);
+    if (iterator != m_peers_gray.get<by_addr>().end()) {
+      m_peers_gray.erase(iterator);
+    }
+
+    return true;
+  }
+  catch (std::exception&) {
+  }
+
   return false;
 }
 //--------------------------------------------------------------------------------------------------

--- a/src/P2p/PeerListManager.cpp
+++ b/src/P2p/PeerListManager.cpp
@@ -170,11 +170,13 @@ bool PeerlistManager::get_peerlist_head(std::list<PeerlistEntry>& bs_head, uint3
 
   BOOST_REVERSE_FOREACH(const peers_indexed::value_type& vl, by_time_index)
   {
-    if (!vl.last_seen)
-      continue;
-    bs_head.push_back(vl);
     if (cnt++ > depth)
       break;
+
+    if (!vl.last_seen)
+      continue;
+
+    bs_head.push_back(vl);
   }
   return true;
 }

--- a/src/P2p/PeerListManager.h
+++ b/src/P2p/PeerListManager.h
@@ -79,9 +79,9 @@ public:
   bool init(bool allow_local_ip);
   size_t get_white_peers_count() const { return m_peers_white.size(); }
   size_t get_gray_peers_count() const { return m_peers_gray.size(); }
-  bool merge_peerlist(const std::list<PeerlistEntry>& outer_bs);
-  bool get_peerlist_head(std::list<PeerlistEntry>& bs_head, uint32_t depth = CryptoNote::P2P_DEFAULT_PEERS_IN_HANDSHAKE) const;
-  bool get_peerlist_full(std::list<AnchorPeerlistEntry>& pl_anchor, std::list<PeerlistEntry>& pl_gray, std::list<PeerlistEntry>& pl_white) const;
+  bool merge_peerlist(const std::vector<PeerlistEntry>& outer_bs);
+  bool get_peerlist_head(std::vector<PeerlistEntry>& bs_head, uint32_t depth = CryptoNote::P2P_DEFAULT_PEERS_IN_HANDSHAKE) const;
+  bool get_peerlist_full(std::list<AnchorPeerlistEntry>& pl_anchor, std::vector<PeerlistEntry>& pl_gray, std::vector<PeerlistEntry>& pl_white) const;
   bool get_white_peer_by_index(PeerlistEntry& p, size_t i) const;
   bool get_gray_peer_by_index(PeerlistEntry& p, size_t i) const;
   bool append_with_peer_anchor(const AnchorPeerlistEntry& pr);

--- a/src/P2p/PeerListManager.h
+++ b/src/P2p/PeerListManager.h
@@ -84,6 +84,7 @@ public:
   bool get_peerlist_full(std::list<AnchorPeerlistEntry>& pl_anchor, std::vector<PeerlistEntry>& pl_gray, std::vector<PeerlistEntry>& pl_white) const;
   bool get_white_peer_by_index(PeerlistEntry& p, size_t i) const;
   bool get_gray_peer_by_index(PeerlistEntry& p, size_t i) const;
+  bool remove_from_peer_gray(PeerlistEntry& p);
   bool append_with_peer_anchor(const AnchorPeerlistEntry& pr);
   bool append_with_peer_white(const PeerlistEntry& pr);
   bool append_with_peer_gray(const PeerlistEntry& pr);

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -1446,8 +1446,8 @@ bool RpcServer::on_get_peer_list(const COMMAND_RPC_GET_PEER_LIST::request& req, 
   }
 
   std::list<AnchorPeerlistEntry> pl_anchor;
-  std::list<PeerlistEntry> pl_wite;
-  std::list<PeerlistEntry> pl_gray;
+  std::vector<PeerlistEntry> pl_wite;
+  std::vector<PeerlistEntry> pl_gray;
   m_p2p.getPeerlistManager().get_peerlist_full(pl_anchor, pl_gray, pl_wite);
   for (const auto& pe : pl_anchor) {
     std::stringstream ss;

--- a/tests/UnitTests/TestPeerlist.cpp
+++ b/tests/UnitTests/TestPeerlist.cpp
@@ -34,7 +34,7 @@ TEST(peer_list, peer_list_general)
 #define ADD_GRAY_NODE(ip_, port_, id_, last_seen_) {  PeerlistEntry ple; ple.last_seen=last_seen_;ple.adr.ip = ip_; ple.adr.port = port_; ple.id = id_;plm.append_with_peer_gray(ple);}  
 #define ADD_WHITE_NODE(ip_, port_, id_, last_seen_) {  PeerlistEntry ple;ple.last_seen=last_seen_; ple.adr.ip = ip_; ple.adr.port = port_; ple.id = id_;plm.append_with_peer_white(ple);}  
 
-#define PRINT_HEAD(step) {std::list<PeerlistEntry> bs_head; bool r = plm.get_peerlist_head(bs_head, 100);std::cout << "step " << step << ": " << bs_head.size() << std::endl;}
+#define PRINT_HEAD(step) {std::vector<PeerlistEntry> bs_head; bool r = plm.get_peerlist_head(bs_head, 100);std::cout << "step " << step << ": " << bs_head.size() << std::endl;}
 
   ADD_GRAY_NODE(MAKE_IP(123,43,12,1), 8080, 121241, 34345);
   ADD_GRAY_NODE(MAKE_IP(123,43,12,2), 8080, 121241, 34345);
@@ -50,7 +50,7 @@ TEST(peer_list, peer_list_general)
   size_t gray_list_size = plm.get_gray_peers_count();
   ASSERT_EQ(gray_list_size, 1);
 
-  std::list<PeerlistEntry> bs_head;
+  std::vector<PeerlistEntry> bs_head;
   bool r = plm.get_peerlist_head(bs_head, 100);
   std::cout << bs_head.size() << std::endl;
   ASSERT_TRUE(r);
@@ -70,7 +70,7 @@ TEST(peer_list, merge_peer_lists)
   //ADD_NODE_TO_PL("\2", \3, 0x\1, (1353346618 -(\4*60*60*24+\5*60*60+\6*60+\7 )));\n
   PeerlistManager plm;
   plm.init(false);
-  std::list<PeerlistEntry> outer_bs;
+  std::vector<PeerlistEntry> outer_bs;
 
 
 }


### PR DESCRIPTION
- Some bandwidth saving in the exchange of peer lists (nodes remember which connections have been sent to which peer addresses and won't send it again)
- Increase the diffusion speed of peer addresses
- Gray peer list housekeeping system
- Ban functionality improvements, added `--ban-list` option to load ban list from file
- Drop peers that spam peer lists
- Protocol: reject empty incoming block messages
- Increase the default number of connections from 8 to 12
- Removed unused code, some code clean up