### PR TITLE
GitHub Action build system removes Boost, Install Boost on Windows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,11 +12,26 @@ jobs:
   build-windows:
     name: Windows
     runs-on: windows-latest
+    env:
+      BOOST_ROOT: C:\thirdparties\boost-1.72.0
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Install Boost
+        shell: cmd
+        run: |
+          choco install wget --no-progress
+          wget -nv -O boost-installer.exe "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download"
+          boost-installer.exe /dir=%BOOST_ROOT% /sp- /verysilent /suppressmsgboxes /norestart
+
+      - name: Install OpenSSL
+        run: choco install openssl
 
       - name: Build
         shell: powershell
@@ -28,7 +43,7 @@ jobs:
           $release_name = "karbo-cli-win64-$krb_ver"
           mkdir "$build_folder"
           cd "$build_folder"
-          cmake -G "Visual Studio 16 2019" -A x64 -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0" ..
+          cmake -G "Visual Studio 16 2019" -A x64 -DBOOST_ROOT="$env:BOOST_ROOT" -DBOOST_INCLUDE_DIRS="$env:BOOST_ROOT/include" ..
           msbuild Karbowanec.sln /p:Configuration=Release /m
           cd src\Release
           Compress-Archive -Path *.exe -DestinationPath "$release_name.zip"
@@ -55,6 +70,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build
         id: build
@@ -95,6 +113,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build
         id: build
@@ -128,6 +149,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build
         id: build
@@ -162,6 +186,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build
         id: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,26 @@ jobs:
   build-windows:
     name: Windows
     runs-on: windows-latest
+    env:
+      BOOST_ROOT: C:\thirdparties\boost-1.72.0
     steps:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Install Boost
+        shell: cmd
+        run: |
+          choco install wget --no-progress
+          wget -nv -O boost-installer.exe "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe/download"
+          boost-installer.exe /dir=%BOOST_ROOT% /sp- /verysilent /suppressmsgboxes /norestart
+
+      - name: Install OpenSSL
+        run: choco install openssl
 
       - name: Build
         shell: powershell
@@ -26,7 +39,7 @@ jobs:
           $release_name = "Karbo-cli-win64-$krb_ver"
           mkdir "$build_folder"
           cd "$build_folder"
-          cmake -G "Visual Studio 16 2019" -A x64 -DBOOST_ROOT="$env:BOOST_ROOT_1_72_0" ..
+          cmake -G "Visual Studio 16 2019" -A x64 -DBOOST_ROOT="$env:BOOST_ROOT" -DBOOST_INCLUDE_DIRS="$env:BOOST_ROOT/include" ..
           msbuild Karbowanec.sln /p:Configuration=Release /m
           cd src\Release
           Compress-Archive -Path *.exe -DestinationPath "$release_name.zip"
@@ -99,6 +112,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build
         id: build
@@ -143,6 +157,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
+          ref: ${{ github.ref }}
 
       - name: Build
         id: build


### PR DESCRIPTION
Because of https://github.com/actions/virtual-environments/issues/2667