### PR TITLE
RPC method checkpayment

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -1301,4 +1301,34 @@ struct COMMAND_RPC_RESOLVE_OPEN_ALIAS {
   };
 };
 
+struct COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID {
+  struct request {
+    std::string payment_id;
+    std::string view_key;
+    std::string address;
+    uint64_t amount;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(payment_id)
+      KV_MEMBER(view_key)
+      KV_MEMBER(address)
+      KV_MEMBER(amount)
+    }
+  };
+
+  struct response {
+    std::vector<Crypto::Hash> transaction_hashes;
+    uint64_t received_amount = 0;
+    uint32_t confirmations = 0;
+    std::string status;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(status)
+      KV_MEMBER(transaction_hashes);
+      KV_MEMBER(received_amount);
+      KV_MEMBER(confirmations);
+    }
+  };
+};
+
 }

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -409,6 +409,7 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
       { "checktransactionbyviewkey", { makeMemberMethod(&RpcServer::on_check_transaction_with_view_key), true } },
       { "checktransactionproof", { makeMemberMethod(&RpcServer::on_check_transaction_proof), true } },
       { "checkreserveproof", { makeMemberMethod(&RpcServer::on_check_reserve_proof), true } },
+      { "checkpayment", { makeMemberMethod(&RpcServer::on_check_payment), true } },
       { "validateaddress", { makeMemberMethod(&RpcServer::on_validate_address), true } },
       { "verifymessage", { makeMemberMethod(&RpcServer::on_verify_message), true } },
       { "submitblock", { makeMemberMethod(&RpcServer::on_submitblock), false } },
@@ -1100,6 +1101,119 @@ bool RpcServer::on_get_transaction_hashes_by_paymentid(const COMMAND_RPC_GET_TRA
     return false;
   }
   rsp.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_check_payment(const COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::request& req, COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::response& rsp) {
+  // get txs with requested payment id
+  Crypto::Hash pid_hash;
+  if (!parse_hash256(req.payment_id, pid_hash)) {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_WRONG_PARAM,
+      "Failed to parse hex representation of payment id. Hex = " + req.payment_id + '.' };
+  }
+  try {
+    rsp.transaction_hashes = m_core.getTransactionHashesByPaymentId(pid_hash);
+  }
+  catch (std::system_error& e) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, e.what() };
+    return false;
+  }
+  catch (std::exception& e) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Error: " + std::string(e.what()) };
+    return false;
+  }
+
+  if (rsp.transaction_hashes.size() == 0) {
+    rsp.status = "not_found";
+    return true;
+  }
+
+  uint64_t received = 0;
+
+  // parse address
+  CryptoNote::AccountPublicAddress address;
+  if (!m_core.currency().parseAccountAddressString(req.address, address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse address " + req.address + '.' };
+  }
+  // parse view key
+  Crypto::Hash view_key_hash;
+  size_t size;
+  if (!Common::fromHex(req.view_key, &view_key_hash, sizeof(view_key_hash), size) || size != sizeof(view_key_hash)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse private view key" };
+  }
+  Crypto::SecretKey viewKey = *(struct Crypto::SecretKey *) &view_key_hash;
+
+  // fetch tx(s)
+  std::list<Crypto::Hash> missed_txs;
+  std::list<Transaction> txs;
+  m_core.getTransactions(rsp.transaction_hashes, txs, missed_txs, true);
+
+  if (missed_txs.size() != 0) {
+    throw JsonRpc::JsonRpcError{
+      CORE_RPC_ERROR_CODE_INTERNAL_ERROR,
+      "Couldn't get transaction with hash: " + Common::podToHex(missed_txs.front()) + '.' };
+  }
+
+  for (const auto& tx : txs) {
+    // get tx pub key
+    Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
+
+    // obtain key derivation
+    Crypto::KeyDerivation derivation;
+    if (!Crypto::generate_key_derivation(txPubKey, viewKey, derivation))
+    {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to generate key derivation from supplied parameters" };
+    }
+
+    // look for outputs
+    size_t keyIndex(0);
+    std::vector<TransactionOutput> outputs;
+    try {
+      for (const TransactionOutput& o : tx.outputs) {
+        if (o.target.type() == typeid(KeyOutput)) {
+          const KeyOutput out_key = boost::get<KeyOutput>(o.target);
+          Crypto::PublicKey pubkey;
+          derive_public_key(derivation, keyIndex, address.spendPublicKey, pubkey);
+          if (pubkey == out_key.key) {
+            received += o.amount;
+          }
+        }
+        ++keyIndex;
+      }
+    }
+    catch (...)
+    {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Unknown error" };
+    }  
+  }
+
+  rsp.received_amount = received;
+
+  for (const auto& h : rsp.transaction_hashes) {
+    Crypto::Hash blockHash;
+    uint32_t blockHeight;
+    if (m_core.getBlockContainingTx(h, blockHash, blockHeight)) {
+      uint32_t confirmations = m_protocolQuery.getObservedHeight() - blockHeight;
+      if (rsp.confirmations < confirmations) {
+        rsp.confirmations = confirmations;
+      }
+    }
+  }
+
+  if (received >= req.amount && rsp.confirmations > 0) {
+    rsp.status = "paid";
+  }
+  else if (received > 0 && received < req.amount) {
+    rsp.status = "underpaid";
+  }
+  else if (rsp.confirmations == 0 && received >= req.amount) {
+    rsp.status = "pending";
+  }
+  else {
+    rsp.status = "unpaid";
+  }
+
   return true;
 }
 

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -130,6 +130,7 @@ private:
   bool on_get_stats_by_heights(const COMMAND_RPC_GET_STATS_BY_HEIGHTS::request& req, COMMAND_RPC_GET_STATS_BY_HEIGHTS::response& res);
   bool on_get_stats_by_heights_range(const COMMAND_RPC_GET_STATS_BY_HEIGHTS_RANGE::request& req, COMMAND_RPC_GET_STATS_BY_HEIGHTS_RANGE::response& res);
   bool on_resolve_open_alias(const COMMAND_RPC_RESOLVE_OPEN_ALIAS::request& req, COMMAND_RPC_RESOLVE_OPEN_ALIAS::response& res);
+  bool on_check_payment(const COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::request& req, COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::response& rsp);
 
   void fill_block_header_response(const Block& blk, bool orphan_status, uint32_t height, const Crypto::Hash& hash, block_header_response& responce);
 


### PR DESCRIPTION
Allows checking payment to given `address` by given `payment id`. It basically combines the functionality of several separate methods in a single convenience method. This method allows to do the payment in several transactions until the total received amount satisfies the requested one, i.e. it allows payment from several wallets, group payment etc.

**Request**
Argument        | Mandatory     | Description           | Format
--------------- | ------------- | --------------------- | ------
address           | yes | Receiving public address | string
amount           | yes | Amount to be paid | int      
payment_id     | yes | Unique Payment Id of the operation | string
view_key         | yes | The *Private View Key* of the receiving address | string

**Response**

Argument         | Description          | Format
---------------- | -------------------- | ------
confirmations   | The number of network confirmations of the paying transaction(s) (largest in case of several transactions) | int
received_amount | The amount received in AU | int
status | Status of payment | string
transaction_hashes | Hashes of transactions with given Payment ID actually paying to provided address | array 

`status` can be:
- `paid`, 
- `underpaid`, 
- `pending`, 
- `not_found`


**Request example:**
```
 {
 	"jsonrpc":"2.0",
 	"method":"checkpayment",
 	"params":{
 		"payment_id":"0bdde0dc45636835319012fe55a4823ee30df2fa84444f81e95f891c48987bdf", 
 		"view_key":"4ff203c944b6537ff160e328aaa3745a6e50c2bf608161f607b661452eebc5e1",
"address":"KaqCQAbx3BSKKv7ED98oQP9QSP3igqgo47hPYZ8q6KZyUY6GnDaQkh9WbVR4DxvmCq8mZcKPg3wfWFJQ5CsyrxPqKcXC3rx",
        "amount": 100000000000000
 	}
 }
```
**Response example:**
```
{
    "jsonrpc": "2.0",
    "result": {
        "confirmations": 80077,
        "received_amount": 1022227324533,
        "status": "paid",
        "transaction_hashes": [
            "01c970533dcfe74f4cacce23997b52f88dda62277a2d720f701ee791f3fcc759"
        ]
    }
}
```


