### PR TITLE
Hardfork: PoW change to bare yespower

### DIFF
--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -1223,39 +1223,44 @@ bool Blockchain::get_block_long_hash(Crypto::cn_context &context, const Block& b
   }
 
   Crypto::Hash hash_1, hash_2;
-  uint32_t currentHeight = boost::get<BaseInput>(b.baseTransaction.inputs[0]).blockIndex;
-  uint32_t maxHeight = std::min<uint32_t>(getCurrentBlockchainHeight() - 1, currentHeight - 1 - m_currency.minedMoneyUnlockWindow());
+  if (b.majorVersion < CryptoNote::BLOCK_MAJOR_VERSION_6) {
+    uint32_t currentHeight = boost::get<BaseInput>(b.baseTransaction.inputs[0]).blockIndex;
+    uint32_t maxHeight = std::min<uint32_t>(getCurrentBlockchainHeight() - 1, currentHeight - 1 - m_currency.minedMoneyUnlockWindow());
 
 #define ITER 128
-  for (uint32_t i = 0; i < ITER; i++) {
-    cn_fast_hash(pot.data(), pot.size(), hash_1);
+    for (uint32_t i = 0; i < ITER; i++) {
+      cn_fast_hash(pot.data(), pot.size(), hash_1);
 
-    for (uint8_t j = 1; j <= 8; j++) {
-      uint8_t chunk[4] = {
-        hash_1.data[j * 4 - 4], 
-        hash_1.data[j * 4 - 3], 
-        hash_1.data[j * 4 - 2], 
-        hash_1.data[j * 4 - 1]
-      };
+      for (uint8_t j = 1; j <= 8; j++) {
+        uint8_t chunk[4] = {
+          hash_1.data[j * 4 - 4], 
+          hash_1.data[j * 4 - 3], 
+          hash_1.data[j * 4 - 2], 
+          hash_1.data[j * 4 - 1]
+        };
 
-      uint32_t n = (chunk[0] << 24) |
-                   (chunk[1] << 16) |
-                   (chunk[2] << 8)  |
-                   (chunk[3]);
+        uint32_t n = (chunk[0] << 24) |
+                     (chunk[1] << 16) |
+                     (chunk[2] << 8)  |
+                     (chunk[3]);
 
-      uint32_t height_j = n % maxHeight;
-      std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
-      const Block& bj = m_blocks[height_j].bl;
+        uint32_t height_j = n % maxHeight;
+        std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
+        const Block& bj = m_blocks[height_j].bl;
 
-      BinaryArray ba;
-      if (!get_block_hashing_blob(bj, ba)) {
-        logger(ERROR, BRIGHT_RED) << "Failed to get_block_hashing_blob of additional block " 
-                                  << j << " at height " << height_j;
-        return false;
+        BinaryArray ba;
+        if (!get_block_hashing_blob(bj, ba)) {
+          logger(ERROR, BRIGHT_RED) << "Failed to get_block_hashing_blob of additional block " 
+                                    << j << " at height " << height_j;
+          return false;
+        }
+
+        pot.insert(std::end(pot), std::begin(ba), std::end(ba));
       }
-
-      pot.insert(std::end(pot), std::begin(ba), std::end(ba));
     }
+  }
+  else {
+    cn_fast_hash(pot.data(), pot.size(), hash_1);
   }
 
   if (!Crypto::y_slow_hash(pot.data(), pot.size(), hash_1, hash_2)) {

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -1245,15 +1245,17 @@ bool Blockchain::get_block_long_hash(Crypto::cn_context &context, const Block& b
                      (chunk[3]);
 
         uint32_t height_j = n % maxHeight;
-        std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
-        const Block& bj = m_blocks[height_j].bl;
+        // use these after removing blobs cache
+        //std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
+        //const Block& bj = m_blocks[height_j].bl;
 
-        BinaryArray ba;
-        if (!get_block_hashing_blob(bj, ba)) {
-          logger(ERROR, BRIGHT_RED) << "Failed to get_block_hashing_blob of additional block " 
-                                    << j << " at height " << height_j;
-          return false;
-        }
+        //BinaryArray ba;
+        //if (!get_block_hashing_blob(bj, ba)) {
+        //  logger(ERROR, BRIGHT_RED) << "Failed to get_block_hashing_blob of additional block " 
+        //                            << j << " at height " << height_j;
+        //  return false;
+        //}
+        BinaryArray& ba = m_blobs[height_j];
 
         pot.insert(std::end(pot), std::begin(ba), std::end(ba));
       }

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2016-2021, The Karbo developers
+// Copyright (c) 2016-2022, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -129,6 +129,8 @@ namespace CryptoNote {
     bool getTransactionIdsByPaymentId(const Crypto::Hash& paymentId, std::vector<Crypto::Hash>& transactionHashes);
     bool isBlockInMainChain(const Crypto::Hash& blockId);
     bool isInCheckpointZone(const uint32_t height);
+
+    bool getHashingBlob(const uint32_t height, BinaryArray& blob);
 
     template<class visitor_t> bool scanOutputKeysForIndexes(const KeyInput& tx_in_to_key, visitor_t& vis, uint32_t* pmax_related_block_height = NULL);
 
@@ -262,6 +264,8 @@ namespace CryptoNote {
     typedef parallel_flat_hash_map<uint64_t, std::vector<std::pair<TransactionIndex, uint16_t>>> outputs_container; //Crypto::Hash - tx hash, size_t - index of out in transaction
     typedef parallel_flat_hash_map<uint64_t, std::vector<MultisignatureOutputUsage>> MultisignatureOutputsContainer;
 
+    typedef std::vector<BinaryArray> hashing_blobs_container;
+
     const Currency& m_currency;
     tx_memory_pool& m_tx_pool;
     std::recursive_mutex m_blockchain_lock; // TODO: add here reader/writer lock
@@ -280,7 +284,6 @@ namespace CryptoNote {
     typedef parallel_flat_hash_map<Crypto::Hash, uint32_t> BlockMap;
     typedef parallel_flat_hash_map<Crypto::Hash, TransactionIndex> TransactionMap;
     typedef BasicUpgradeDetector<Blocks> UpgradeDetector;
-
     friend class BlockCacheSerializer;
     friend class BlockchainIndicesSerializer;
 
@@ -288,6 +291,9 @@ namespace CryptoNote {
     CryptoNote::BlockIndex m_blockIndex;
     TransactionMap m_transactionMap;
     MultisignatureOutputsContainer m_multisignatureOutputs;
+
+    hashing_blobs_container m_blobs;
+
     UpgradeDetector m_upgradeDetectorV2;
     UpgradeDetector m_upgradeDetectorV3;
     UpgradeDetector m_upgradeDetectorV4;

--- a/src/CryptoNoteCore/Miner.cpp
+++ b/src/CryptoNoteCore/Miner.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2016-2021, The Karbo developers
+// Copyright (c) 2016-2022, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -213,12 +213,15 @@ namespace CryptoNote
       Crypto::secret_key_to_public_key(m_mine_account.spendSecretKey, m_mine_account.address.spendPublicKey);
       Crypto::secret_key_to_public_key(m_mine_account.viewSecretKey, m_mine_account.address.viewPublicKey);
 
-      m_threads_total = 1;
       m_do_mining = true;
-      if (config.miningThreads > 0) {
-        m_threads_total = config.miningThreads;
-      }
     }
+
+    m_threads_total = 1;
+    if (config.miningThreads > 0) {
+      m_threads_total = config.miningThreads;
+    }
+
+    m_do_print_hashrate = config.printHashrate;
 
     return true;
   }

--- a/src/CryptoNoteCore/Miner.h
+++ b/src/CryptoNoteCore/Miner.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2016-2021, The Karbo developers
+// Copyright (c) 2016-2022, The Karbo developers
 //
 // This file is part of Karbo.
 //

--- a/src/CryptoNoteCore/MinerConfig.cpp
+++ b/src/CryptoNoteCore/MinerConfig.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2016-2022, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -26,6 +27,7 @@ const command_line::arg_descriptor<std::string> arg_extra_messages   = { "extra-
 const command_line::arg_descriptor<std::string> arg_mining_spend_key = { "mining-spend-key", "Specify secret spend key to sign the mined block", "", true };
 const command_line::arg_descriptor<std::string> arg_mining_view_key  = { "mining-view-key", "Specify secret view key of miner address", "", true };
 const command_line::arg_descriptor<uint32_t>    arg_mining_threads   = { "mining-threads", "Specify mining threads count", 0, true };
+const command_line::arg_descriptor<bool>        arg_print_hashrate   = { "print-hashrate", "Show hashrate", true };
 }
 
 MinerConfig::MinerConfig() {
@@ -37,6 +39,7 @@ void MinerConfig::initOptions(boost::program_options::options_description& desc)
   command_line::add_arg(desc, arg_mining_spend_key);
   command_line::add_arg(desc, arg_mining_view_key);
   command_line::add_arg(desc, arg_mining_threads);
+  command_line::add_arg(desc, arg_print_hashrate);
 }
 
 void MinerConfig::init(const boost::program_options::variables_map& options) {
@@ -54,6 +57,10 @@ void MinerConfig::init(const boost::program_options::variables_map& options) {
 
   if (command_line::has_arg(options, arg_mining_threads)) {
     miningThreads = command_line::get_arg(options, arg_mining_threads);
+  }
+
+  if (command_line::has_arg(options, arg_print_hashrate)) {
+    printHashrate = true;
   }
 }
 

--- a/src/CryptoNoteCore/MinerConfig.h
+++ b/src/CryptoNoteCore/MinerConfig.h
@@ -1,4 +1,5 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2016-2022, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -35,6 +36,7 @@ public:
   std::string miningSpendKey;
   std::string miningViewKey;
   uint32_t miningThreads;
+  bool printHashrate = false;
 };
 
 } //namespace CryptoNote

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -198,6 +198,7 @@ void NodeRpcProxy::workerThread(const INode::Callback& initialized_callback) {
     contextGroup.spawn([this]() {
       Timer pullTimer(*m_dispatcher);
       while (!m_stop) {
+        getFeeAddress(); // Get public node's fee info
         updateNodeStatus();
         if (!m_stop) {
           pullTimer.sleep(std::chrono::milliseconds(m_pullInterval));
@@ -225,7 +226,6 @@ void NodeRpcProxy::updateNodeStatus() {
     updateBlockchainStatus();
     updateBlockchain = !updatePoolStatus();
   }
-  getFeeAddress(); // Get public node's fee info
 }
 
 bool NodeRpcProxy::updatePoolStatus() {


### PR DESCRIPTION
This requires a hardfork. Since BloDHa doesn't really limit beast CPUs, moreover, heavily hinders sync speed of DB-based Karbo 2, we should ditch it. Then after the hardfork remove hashing blob caching altogether, checkpoint will allow to sync fast past blodha blocks, those who wishes sync at full validation will just have to wait a bit longer for validation of those blodha blocks.