### PR TITLE
Change reward calculation

### DIFF
--- a/src/CryptoNoteCore/Currency.cpp
+++ b/src/CryptoNoteCore/Currency.cpp
@@ -149,29 +149,28 @@ namespace CryptoNote {
 		}
 	}
 
-  uint64_t Currency::calculateReward(uint64_t alreadyGeneratedCoins) const {
-    // assert(alreadyGeneratedCoins <= m_moneySupply);
-    assert(m_emissionSpeedFactor > 0 && m_emissionSpeedFactor <= 8 * sizeof(uint64_t));
+	uint64_t Currency::calculateReward(uint64_t alreadyGeneratedCoins) const {
+		// assert(alreadyGeneratedCoins <= m_moneySupply);
+		assert(m_emissionSpeedFactor > 0 && m_emissionSpeedFactor <= 8 * sizeof(uint64_t));
 
-    uint64_t baseReward = (m_moneySupply - alreadyGeneratedCoins) >> m_emissionSpeedFactor;
+		uint64_t baseRewardInitial, baseRewardTail, baseReward;
 
-    // Tail emission
-    if (alreadyGeneratedCoins + CryptoNote::parameters::TAIL_EMISSION_REWARD >= m_moneySupply || baseReward < CryptoNote::parameters::TAIL_EMISSION_REWARD)
-    {
-      // flat rate tail emission reward,
-      // inflation slowly diminishing in relation to supply
-      //baseReward = CryptoNote::parameters::TAIL_EMISSION_REWARD;
-      // changed to
-      // Friedman's k-percent rule,
-      // inflation 2% of total coins in circulation per year
-      // according to Whitepaper v. 1, p. 16 (with change of 1% to 2%)
-      const uint64_t blocksInOneYear = expectedNumberOfBlocksPerDay() * 365;
-      uint64_t twoPercentOfEmission = static_cast<uint64_t>(static_cast<double>(alreadyGeneratedCoins) / 100.0 * 2.0);
-      baseReward = twoPercentOfEmission / blocksInOneYear;
-    }
+		baseRewardInitial = alreadyGeneratedCoins < m_moneySupply ? (m_moneySupply - alreadyGeneratedCoins) >> m_emissionSpeedFactor : CryptoNote::parameters::TAIL_EMISSION_REWARD;
+		// Tail emission
+		// Flat rate tail emission reward, inflation slowly diminishing in relation to supply
+		// baseRewardTail = CryptoNote::parameters::TAIL_EMISSION_REWARD;
+		// changed to Friedman's k-percent rule, inflation 2% of total coins in circulation p.a.
+		const uint64_t blocksInOneYear = expectedNumberOfBlocksPerDay() * 365;
+		uint64_t twoPercentOfEmission = alreadyGeneratedCoins / 100 * 2; // sic! use integers
+		baseRewardTail = twoPercentOfEmission / blocksInOneYear;
 
-    return baseReward;
-  }
+		baseReward = std::max<uint64_t>(baseRewardInitial, baseRewardTail);
+
+		logger(DEBUGGING) << "Init. reward: " << formatAmount(baseRewardInitial);
+		logger(DEBUGGING) << "Tail  reward: " << formatAmount(baseRewardTail);
+
+		return baseReward;
+	}
 
   bool Currency::getBlockReward(uint8_t blockMajorVersion, size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins,
     uint64_t fee, uint64_t& reward, int64_t& emissionChange) const {


### PR DESCRIPTION
Trigger tail emission sooner with a **smooth transition of reward amount**: use maximal from `initial` and `tail` emission reward. 

When eventually they meet, there will be a switch to the tail emission and this will happen sooner than in the previous implementation.

This is a cleaner and more correct solution, providing a smooth transition of reward amount because in previous implementation there would be a jump from 1 KRB to 1.5~ KRB as there tail emission kicks in only when reward drops to 1 KRB.