### PR TITLE
Workaround queryBlocksLite backward compatible with old wallets

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1050,6 +1050,8 @@ bool Core::queryBlocksLite(const std::vector<Crypto::Hash>& knownBlockIds, uint6
       std::list<Crypto::Hash> missedTxs;
       lbs->getTransactions(b.transactionHashes, txs, missedTxs);
 
+      b.majorVersion = BLOCK_MAJOR_VERSION_4; // dirty hack: make it backward compatible with old wallets, i.e. serialize without signature
+
       item.block = asString(toBinaryArray(b));
 
       for (const auto& tx: txs) {

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1050,7 +1050,7 @@ bool Core::queryBlocksLite(const std::vector<Crypto::Hash>& knownBlockIds, uint6
       std::list<Crypto::Hash> missedTxs;
       lbs->getTransactions(b.transactionHashes, txs, missedTxs);
 
-      b.majorVersion = BLOCK_MAJOR_VERSION_4; // dirty hack: make it backward compatible with old wallets, i.e. serialize without signature
+      b.majorVersion = BLOCK_MAJOR_VERSION_4; // Workaround backward compatible with old wallets, i.e. serialize without signature
 
       item.block = asString(toBinaryArray(b));
 


### PR DESCRIPTION
Old pre-YeSPOWer wallets can't parse Block `signature` in the `queryBlocksLite` response and therefore cannot sync.  This solves the issue with serializing without `signature` by changing the block version to 4. This workaround looks worth enabling older clients to sync again.