### PR TITLE
Fix remote node fee in simplewallet

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -131,6 +131,7 @@ const char     MINER_CONFIG_FILE_NAME[]                      = "miner_conf.json"
 } // parameters
 
 const char     CRYPTONOTE_NAME[]                             = "karbowanec";
+const char     CRYPTONOTE_TICKER[]                           = "KRB";
 const char     GENESIS_COINBASE_TX_HEX[]                     = 
 "01"                                                                // tx version
 "0a"                                                                // unlock time

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -652,7 +652,8 @@ simple_wallet::simple_wallet(System::Dispatcher& dispatcher, const CryptoNote::C
   m_initResultPromise(nullptr),
   m_walletSynchronized(false),
   m_trackingWallet(false),
-  m_do_not_relay_tx(false)
+  m_do_not_relay_tx(false),
+  m_initial_remote_fee_mess(false)
 {
   m_consoleHandler.setHandler("start_mining", std::bind(&simple_wallet::start_mining, this, std::placeholders::_1), "start_mining [<number_of_threads>] - Start mining in daemon");
   m_consoleHandler.setHandler("stop_mining", std::bind(&simple_wallet::stop_mining, this, std::placeholders::_1), "Stop mining in daemon");
@@ -837,10 +838,10 @@ bool simple_wallet::get_reserve_proof(const std::vector<std::string> &args)
 
   try {
     const std::string sig_str = m_wallet->getReserveProof(reserve, args.size() == 2 ? args[1] : "");
-    
+
     //logger(INFO, BRIGHT_WHITE) << "\n\n" << sig_str << "\n\n" << std::endl;
 
-    const std::string filename = "reserve_proof_" + args[0] + "KRB.txt";
+    const std::string filename = "reserve_proof_" + args[0] + CryptoNote::CRYPTONOTE_TICKER + ".txt";
     boost::system::error_code ec;
     if (boost::filesystem::exists(filename, ec)) {
       boost::filesystem::remove(filename, ec);
@@ -1049,20 +1050,6 @@ bool simple_wallet::init(const boost::program_options::variables_map& vm)
   if (error) {
     fail_msg_writer() << "failed to init NodeRPCProxy: " << error.message();
     return false;
-  }
-
-  std::string remote_node_fee_address = m_node->feeAddress();
-  if (!remote_node_fee_address.empty()) {
-    uint64_t remote_node_fee_amount = m_node->feeAmount();
-    std::stringstream feemsg;
-    feemsg << std::endl << "You have connected to a node that charges "
-           << "a fee to send transactions." << std::endl << std::endl
-           << "The node's fee for sending transactions is "
-           << (remote_node_fee_amount == 0 ? "0.25% of transaction amount, but no more than " + m_currency.formatAmount(CryptoNote::parameters::MAXIMUM_FEE) : m_currency.formatAmount(remote_node_fee_amount))
-           << " KRB" << std::endl << std::endl 
-           << "If you don't want to pay the node fee, please run your own node."
-           << std::endl;
-    std::cout << WarningMsg(feemsg.str()) << std::endl;
   }
 
   if (m_restore_wallet && m_wallet_file_arg.empty()) {
@@ -1883,6 +1870,24 @@ void simple_wallet::initCompleted(std::error_code result) {
 void simple_wallet::connectionStatusUpdated(bool connected) {
   if (connected) {
     logger(INFO, GREEN) << "Wallet connected to daemon.";
+
+    if (!m_initial_remote_fee_mess) {
+      std::string remote_node_fee_address = m_node->feeAddress();
+      if (!remote_node_fee_address.empty()) {
+        uint64_t remote_node_fee_amount = m_node->feeAmount();
+        std::stringstream feemsg;
+        feemsg << std::endl << "You have connected to a node that charges "
+          << "a fee to send transactions." << std::endl
+          << "The node's fee for sending transactions is "
+          << (remote_node_fee_amount == 0 ? "0.25% of transaction amount, but no more than "
+            + m_currency.formatAmount(CryptoNote::parameters::MAXIMUM_FEE) : m_currency.formatAmount(remote_node_fee_amount))
+          << " " << CryptoNote::CRYPTONOTE_TICKER << "." << std::endl
+          << "If you don't want to pay the node fee, please run your own node."
+          << std::endl;
+        std::cout << InformationMsg(feemsg.str()) << std::endl;
+      }
+      m_initial_remote_fee_mess = true;
+    }
   } else {
     printConnectionError();
   }

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -211,6 +211,7 @@ namespace CryptoNote
     bool m_daemon_no_verify;
     bool m_do_not_relay_tx;
     bool m_dump_keys_file;
+    bool m_initial_remote_fee_mess;
     
     std::unique_ptr<std::promise<std::error_code>> m_initResultPromise;
 


### PR DESCRIPTION
I didn't like the code in the first place, besides the message about the remote node fee was never shown because at that point it wasn't connected to the node and had not yet its fee data. 

Now it correctly shows such message:

```
**********************************************************************
2022-Jun-30 15:23:04.859926 INFO    Wallet connected to daemon.

You have connected to a node that charges a fee to send transactions.
The node's fee for sending transactions is 0.010000000000 KRB.
If you don't want to pay the node fee, please run your own node.

```

Also added a ticker constant for further reuse throughout the code and replaced hardcoded KRB in simplewallet for a starter. 