### PR TITLE
Wallet RPC without Dispatcher

### DIFF
--- a/src/Common/JsonValue.cpp
+++ b/src/Common/JsonValue.cpp
@@ -109,7 +109,7 @@ JsonValue::JsonValue(Bool value) : type(BOOL), valueBool(value) {
 JsonValue::JsonValue(Integer value) : type(INTEGER), valueInteger(value) {
 }
 
-JsonValue::JsonValue(Nil) : type(NIL) {
+JsonValue::JsonValue(Nil_) : type(NIL) {
 }
 
 JsonValue::JsonValue(const Object& value) {
@@ -308,7 +308,7 @@ JsonValue& JsonValue::operator=(Integer value) {
   return *this;
 }
 
-JsonValue& JsonValue::operator=(Nil) {
+JsonValue& JsonValue::operator=(Nil_) {
   if (type != NIL) {
     destructValue();
     type = NIL;

--- a/src/Common/JsonValue.cpp
+++ b/src/Common/JsonValue.cpp
@@ -109,7 +109,7 @@ JsonValue::JsonValue(Bool value) : type(BOOL), valueBool(value) {
 JsonValue::JsonValue(Integer value) : type(INTEGER), valueInteger(value) {
 }
 
-JsonValue::JsonValue(Nil_) : type(NIL) {
+JsonValue::JsonValue(Nile) : type(NIL) {
 }
 
 JsonValue::JsonValue(const Object& value) {
@@ -308,7 +308,7 @@ JsonValue& JsonValue::operator=(Integer value) {
   return *this;
 }
 
-JsonValue& JsonValue::operator=(Nil_) {
+JsonValue& JsonValue::operator=(Nile) {
   if (type != NIL) {
     destructValue();
     type = NIL;

--- a/src/Common/JsonValue.h
+++ b/src/Common/JsonValue.h
@@ -22,9 +22,7 @@ public:
   typedef std::vector<JsonValue> Array;
   typedef bool Bool;
   typedef int64_t Integer;
-#ifndef Nil
-  typedef std::nullptr_t Nil;
-#endif
+  typedef std::nullptr_t Nil_;
   typedef std::map<Key, JsonValue> Object;
   typedef double Real;
   typedef std::string String;
@@ -47,7 +45,7 @@ public:
   JsonValue(Array&& value);
   explicit JsonValue(Bool value);
   JsonValue(Integer value);
-  JsonValue(Nil value);
+  JsonValue(Nil_ value);
   JsonValue(const Object& value);
   JsonValue(Object&& value);
   JsonValue(Real value);
@@ -66,7 +64,7 @@ public:
   JsonValue& operator=(Array&& value);
   //JsonValue& operator=(Bool value);
   JsonValue& operator=(Integer value);
-  JsonValue& operator=(Nil value);
+  JsonValue& operator=(Nil_ value);
   JsonValue& operator=(const Object& value);
   JsonValue& operator=(Object&& value);
   JsonValue& operator=(Real value);

--- a/src/Common/JsonValue.h
+++ b/src/Common/JsonValue.h
@@ -22,7 +22,7 @@ public:
   typedef std::vector<JsonValue> Array;
   typedef bool Bool;
   typedef int64_t Integer;
-  typedef std::nullptr_t Nil_;
+  typedef std::nullptr_t Nile;
   typedef std::map<Key, JsonValue> Object;
   typedef double Real;
   typedef std::string String;
@@ -45,7 +45,7 @@ public:
   JsonValue(Array&& value);
   explicit JsonValue(Bool value);
   JsonValue(Integer value);
-  JsonValue(Nil_ value);
+  JsonValue(Nile value);
   JsonValue(const Object& value);
   JsonValue(Object&& value);
   JsonValue(Real value);
@@ -64,7 +64,7 @@ public:
   JsonValue& operator=(Array&& value);
   //JsonValue& operator=(Bool value);
   JsonValue& operator=(Integer value);
-  JsonValue& operator=(Nil_ value);
+  JsonValue& operator=(Nile value);
   JsonValue& operator=(const Object& value);
   JsonValue& operator=(Object&& value);
   JsonValue& operator=(Real value);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2541,7 +2541,6 @@ int main(int argc, char* argv[]) {
   System::Dispatcher dispatcher;
   System::Event m_stopComplete(dispatcher);
 
-
   po::variables_map vm;
 
   bool r = command_line::handle_error_helper(desc_all, [&]() {
@@ -2684,7 +2683,7 @@ int main(int argc, char* argv[]) {
       return 1;
     }
 
-    Tools::wallet_rpc_server wrpc(/*dispatcher,*/ logManager, *wallet, *node, currency, walletFileName);
+    Tools::wallet_rpc_server wrpc(logManager, *wallet, *node, currency, walletFileName);
 
     if (!wrpc.init(vm)) {
       logger(ERROR, BRIGHT_RED) << "Failed to initialize wallet rpc server";
@@ -2692,7 +2691,7 @@ int main(int argc, char* argv[]) {
     }
 
     Tools::SignalHandler::install([&m_stopComplete, &dispatcher, &wrpc, &wallet] {
-      wrpc.send_stop_signal();
+      wrpc.stop();
 
       dispatcher.remoteSpawn([&] {
         m_stopComplete.set();
@@ -2710,7 +2709,6 @@ int main(int argc, char* argv[]) {
     wrpc.run();
 
     m_stopComplete.wait();
-
 
     logger(INFO) << "Stopped wallet rpc server";
     

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2539,6 +2539,8 @@ int main(int argc, char* argv[]) {
   Logging::LoggerManager logManager;
   Logging::LoggerRef logger(logManager, "simplewallet");
   System::Dispatcher dispatcher;
+  System::Event m_stopComplete(dispatcher);
+
 
   po::variables_map vm;
 
@@ -2682,15 +2684,20 @@ int main(int argc, char* argv[]) {
       return 1;
     }
 
-    Tools::wallet_rpc_server wrpc(dispatcher, logManager, *wallet, *node, currency, walletFileName);
+    Tools::wallet_rpc_server wrpc(/*dispatcher,*/ logManager, *wallet, *node, currency, walletFileName);
 
     if (!wrpc.init(vm)) {
       logger(ERROR, BRIGHT_RED) << "Failed to initialize wallet rpc server";
       return 1;
     }
 
-    Tools::SignalHandler::install([&wrpc, &wallet] {
+    Tools::SignalHandler::install([&m_stopComplete, &dispatcher, &wrpc, &wallet] {
       wrpc.send_stop_signal();
+
+      dispatcher.remoteSpawn([&] {
+        m_stopComplete.set();
+      });
+
     });
 
     bool enable_ssl;
@@ -2701,6 +2708,10 @@ int main(int argc, char* argv[]) {
     if (enable_ssl) ssl_info += std::string(", SSL on address ") + bind_address_ssl;
     logger(INFO) << "Starting wallet rpc server on address " << bind_address << ssl_info;
     wrpc.run();
+
+    m_stopComplete.wait();
+
+
     logger(INFO) << "Stopped wallet rpc server";
     
     try {

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -50,6 +50,8 @@
 #include "Logging/LoggerRef.h"
 #include "Logging/LoggerManager.h"
 #include "System/Dispatcher.h"
+#include "System/Event.h"
+#include "System/RemoteContext.h"
 #include "System/Ipv4Address.h"
 
 using namespace Logging;
@@ -219,6 +221,7 @@ namespace CryptoNote
     const CryptoNote::Currency& m_currency;
     Logging::LoggerManager& m_logManager;
     System::Dispatcher& m_dispatcher;
+    
     Logging::LoggerRef logger;
 
     std::unique_ptr<CryptoNote::NodeRpcProxy> m_node;

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -221,7 +221,6 @@ namespace CryptoNote
     const CryptoNote::Currency& m_currency;
     Logging::LoggerManager& m_logManager;
     System::Dispatcher& m_dispatcher;
-    
     Logging::LoggerRef logger;
 
     std::unique_ptr<CryptoNote::NodeRpcProxy> m_node;

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -75,15 +75,12 @@ void wallet_rpc_server::init_options(boost::program_options::options_description
 //------------------------------------------------------------------------------------------------------------------------------
 
 wallet_rpc_server::wallet_rpc_server(
-  //System::Dispatcher& dispatcher,
   Logging::ILogger& log,
   CryptoNote::IWalletLegacy& w,
   CryptoNote::INode& n,
   CryptoNote::Currency& currency,
   const std::string& walletFilename) :
   logger(log, "WalletRpc"),
-  //m_dispatcher(dispatcher),
-  //m_stopComplete(dispatcher),
   m_wallet(w),
   m_node(n),
   m_currency(currency),
@@ -102,32 +99,12 @@ wallet_rpc_server::~wallet_rpc_server() {
 bool wallet_rpc_server::run()
 {
   if (m_run_ssl) {
-    //m_workers.emplace_back(std::unique_ptr<System::RemoteContext<void>>(
-    //  new System::RemoteContext<void>(m_dispatcher, std::bind(&wallet_rpc_server::listen_ssl, this, m_bind_ip, m_port_ssl)))
-    //);
     m_workers.push_back(std::thread(std::bind(&wallet_rpc_server::listen_ssl, this, m_bind_ip, m_port_ssl)));
   }
 
-  //m_workers.emplace_back(std::unique_ptr<System::RemoteContext<void>>(
-  //  new System::RemoteContext<void>(m_dispatcher, std::bind(&wallet_rpc_server::listen, this, m_bind_ip, m_port)))
-  //);
   m_workers.push_back(std::thread(std::bind(&wallet_rpc_server::listen, this, m_bind_ip, m_port)));
 
-  //if (!noEvent)
-  //  m_stopComplete.wait();
-
   return true;
-}
-
-//------------------------------------------------------------------------------------------------------------------------------
-
-void wallet_rpc_server::send_stop_signal()
-{
-  //m_dispatcher.remoteSpawn([this]
-  //{
-    stop();
-    //m_stopComplete.set();
-  //});
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
@@ -714,7 +691,7 @@ bool wallet_rpc_server::on_stop_wallet(const wallet_rpc::COMMAND_RPC_STOP::reque
     logger(Logging::ERROR) << "Couldn't save wallet: " << e.what();
     throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR, std::string("Couldn't save wallet: ") + e.what());
   }
-  wallet_rpc_server::send_stop_signal();
+  wallet_rpc_server::stop();
   return true;
 }
 

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -38,7 +38,6 @@ class wallet_rpc_server
 {
 public:
   wallet_rpc_server(
-    //System::Dispatcher& dispatcher,
     Logging::ILogger& log,
     CryptoNote::IWalletLegacy &w, 
     CryptoNote::INode &n, 

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -31,8 +31,6 @@
 #include "Logging/LoggerRef.h"
 #include "WalletRpcServerCommandsDefinitions.h"
 #include "WalletLegacy/WalletLegacy.h"
-//#include "System/Dispatcher.h"
-//#include "System/RemoteContext.h"
 
 namespace Tools
 {
@@ -63,7 +61,6 @@ public:
   void getServerConf(std::string &bind_address, std::string &bind_address_ssl, bool &enable_ssl);
     
   bool run();
-  void send_stop_signal();
   void stop();
 
 private:
@@ -104,9 +101,6 @@ private:
   httplib::Server* http;
   httplib::SSLServer* https;
   Logging::LoggerRef logger;
-  //System::Dispatcher& m_dispatcher;
-  //System::Event m_stopComplete;
-  //std::vector<std::unique_ptr<System::RemoteContext<void>>> m_workers;
   std::list<std::thread> m_workers;
 
   bool m_enable_ssl;

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -21,6 +21,7 @@
 #pragma  once
 
 #include <future>
+#include <thread>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
@@ -30,8 +31,8 @@
 #include "Logging/LoggerRef.h"
 #include "WalletRpcServerCommandsDefinitions.h"
 #include "WalletLegacy/WalletLegacy.h"
-#include "System/Dispatcher.h"
-#include "System/RemoteContext.h"
+//#include "System/Dispatcher.h"
+//#include "System/RemoteContext.h"
 
 namespace Tools
 {
@@ -39,7 +40,7 @@ class wallet_rpc_server
 {
 public:
   wallet_rpc_server(
-    System::Dispatcher& dispatcher, 
+    //System::Dispatcher& dispatcher,
     Logging::ILogger& log,
     CryptoNote::IWalletLegacy &w, 
     CryptoNote::INode &n, 
@@ -61,7 +62,7 @@ public:
   bool init(const boost::program_options::variables_map& vm);
   void getServerConf(std::string &bind_address, std::string &bind_address_ssl, bool &enable_ssl);
     
-  bool run(bool noEvent = false);
+  bool run();
   void send_stop_signal();
   void stop();
 
@@ -103,9 +104,10 @@ private:
   httplib::Server* http;
   httplib::SSLServer* https;
   Logging::LoggerRef logger;
-  System::Dispatcher& m_dispatcher;
-  System::Event m_stopComplete;
-  std::vector<std::unique_ptr<System::RemoteContext<void>>> m_workers;
+  //System::Dispatcher& m_dispatcher;
+  //System::Event m_stopComplete;
+  //std::vector<std::unique_ptr<System::RemoteContext<void>>> m_workers;
+  std::list<std::thread> m_workers;
 
   bool m_enable_ssl;
   bool m_run_ssl;


### PR DESCRIPTION
Get rid of Dispatcher in WalletRpcServer because it causes exceptions when WalletRpcServer is used in GUI wallet.

We can move Event await to simplewallet.