### PR TITLE
Use legacy HttpServer in wallet RPC

### DIFF
--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -1093,9 +1093,7 @@ void CryptoNoteProtocolHandler::relay_transactions(NOTIFY_NEW_TRANSACTIONS::requ
       if (!m_stemPool.hasTransaction(transactionHash)) {
         logger(Logging::DEBUGGING) << "Adding relayed transaction " << transactionHash << " to stempool";
         auto txblob = *tx_blob_it;
-        //m_dispatcher.remoteSpawn([this, transactionHash, txblob] {
-          m_stemPool.addTransaction(transactionHash, txblob);
-        //});
+        m_stemPool.addTransaction(transactionHash, txblob);
         txHashes.push_back(transactionHash);
       }
     }

--- a/src/HTTP/HttpClient.cpp
+++ b/src/HTTP/HttpClient.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Karbo.
+//
+// Karbo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Karbo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Karbo.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "HttpClient.h"
+
+#include <HTTP/HttpParser.h>
+#include <System/Ipv4Resolver.h>
+#include <System/Ipv4Address.h>
+#include <System/TcpConnector.h>
+
+namespace CryptoNote {
+
+HttpClient::HttpClient(System::Dispatcher& dispatcher, const std::string& address, uint16_t port) :
+  m_dispatcher(dispatcher), m_address(address), m_port(port) {
+}
+
+HttpClient::~HttpClient() {
+  if (m_connected) {
+    disconnect();
+  }
+}
+
+void HttpClient::request(const HttpRequest &req, HttpResponse &res) {
+  if (!m_connected) {
+    connect();
+  }
+
+  try {
+    std::iostream stream(m_streamBuf.get());
+    HttpParser parser;
+    stream << req;
+    stream.flush();
+    parser.receiveResponse(stream, res);
+  } catch (const std::exception &) {
+    disconnect();
+    throw;
+  }
+}
+
+void HttpClient::connect() {
+  try {
+    auto ipAddr = System::Ipv4Resolver(m_dispatcher).resolve(m_address);
+    m_connection = System::TcpConnector(m_dispatcher).connect(ipAddr, m_port);
+    m_streamBuf.reset(new System::TcpStreambuf(m_connection));
+    m_connected = true;
+  } catch (const std::exception& e) {
+    throw ConnectException(e.what());
+  }
+}
+
+bool HttpClient::isConnected() const {
+  return m_connected;
+}
+
+void HttpClient::disconnect() {
+  m_streamBuf.reset();
+  try {
+    m_connection.write(nullptr, 0); //Socket shutdown.
+  } catch (std::exception&) {
+    //Ignoring possible exception.
+  }
+
+  try {
+    m_connection = System::TcpConnection();
+  } catch (std::exception&) {
+    //Ignoring possible exception.
+  }
+
+  m_connected = false;
+}
+
+ConnectException::ConnectException(const std::string& whatArg) : std::runtime_error(whatArg.c_str()) {
+}
+
+}

--- a/src/HTTP/HttpClient.h
+++ b/src/HTTP/HttpClient.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Karbo.
+//
+// Karbo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Karbo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Karbo.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <memory>
+
+#include <Common/base64.hpp>
+#include <HTTP/HttpRequest.h>
+#include <HTTP/HttpResponse.h>
+#include <System/TcpConnection.h>
+#include <System/TcpStream.h>
+#include <Rpc/JsonRpc.h>
+
+#include "Serialization/SerializationTools.h"
+
+namespace CryptoNote {
+
+class ConnectException : public std::runtime_error  {
+public:
+  ConnectException(const std::string& whatArg);
+};
+
+class HttpClient {
+public:
+
+  HttpClient(System::Dispatcher& dispatcher, const std::string& address, uint16_t port);
+  ~HttpClient();
+  void request(const HttpRequest& req, HttpResponse& res);
+  
+  bool isConnected() const;
+
+private:
+  void connect();
+  void disconnect();
+
+  const std::string m_address;
+  const uint16_t m_port;
+
+  bool m_connected = false;
+  System::Dispatcher& m_dispatcher;
+  System::TcpConnection m_connection;
+  std::unique_ptr<System::TcpStreambuf> m_streamBuf;
+};
+
+template <typename Request, typename Response>
+void invokeJsonCommand(HttpClient& client, const std::string& url, const Request& req, Response& res, const std::string& user = "", const std::string& password = "") {
+  HttpRequest hreq;
+  HttpResponse hres;
+
+  hreq.addHeader("Content-Type", "application/json");
+  if (!user.empty() || !password.empty()) {
+    hreq.addHeader("Authorization", "Basic " + base64::encode(Common::asBinaryArray(user + ":" + password)));
+  }
+  hreq.setUrl(url);
+  hreq.setBody(storeToJson(req));
+  client.request(hreq, hres);
+
+  if (hres.getStatus() != HttpResponse::STATUS_200) {
+    throw std::runtime_error("HTTP status: " + std::to_string(hres.getStatus()));
+  }
+
+  if (!loadFromJson(res, hres.getBody())) {
+    throw std::runtime_error("Failed to parse JSON response");
+  }
+}
+
+template <typename Request, typename Response>
+void invokeJsonRpcCommand(HttpClient& client, const std::string& method, const Request& req, Response& res, const std::string& user = "", const std::string& password = "") {
+  try {
+
+    JsonRpc::JsonRpcRequest jsReq;
+
+    jsReq.setMethod(method);
+    jsReq.setParams(req);
+
+    HttpRequest httpReq;
+    HttpResponse httpRes;
+
+    httpReq.addHeader("Content-Type", "application/json");
+    if (!user.empty() || !password.empty()) {
+      httpReq.addHeader("Authorization", "Basic " + base64::encode(Common::asBinaryArray(user + ":" + password)));
+    }
+    httpReq.setUrl("/json_rpc");
+    httpReq.setBody(jsReq.getBody());
+
+    client.request(httpReq, httpRes);
+
+    JsonRpc::JsonRpcResponse jsRes;
+
+    //if (httpRes.getStatus() == HttpResponse::STATUS_200) {
+      jsRes.parse(httpRes.getBody());
+      if (!jsRes.getResult(res)) {
+        throw std::runtime_error("HTTP status: " + std::to_string(httpRes.getStatus()));
+      }
+    //}
+
+  } catch (const ConnectException&) {
+    throw std::runtime_error("HTTP status: CONNECT_ERROR");
+  } catch (const std::exception&) {
+    throw std::runtime_error("HTTP status: NETWORK_ERROR");
+  }
+}
+
+template <typename Request, typename Response>
+void invokeBinaryCommand(HttpClient& client, const std::string& url, const Request& req, Response& res, const std::string& user = "", const std::string& password = "") {
+  HttpRequest hreq;
+  HttpResponse hres;
+
+  if (!user.empty() || !password.empty()) {
+    hreq.addHeader("Authorization", "Basic " + Tools::Base64::encode(user + ":" + password));
+  }
+  hreq.setUrl(url);
+  hreq.setBody(storeToBinaryKeyValue(req));
+  client.request(hreq, hres);
+
+  if (!loadFromBinaryKeyValue(res, hres.getBody())) {
+    throw std::runtime_error("Failed to parse binary response");
+  }
+}
+  
+}

--- a/src/HTTP/HttpClient.h
+++ b/src/HTTP/HttpClient.h
@@ -122,7 +122,7 @@ void invokeBinaryCommand(HttpClient& client, const std::string& url, const Reque
   HttpResponse hres;
 
   if (!user.empty() || !password.empty()) {
-    hreq.addHeader("Authorization", "Basic " + Tools::Base64::encode(user + ":" + password));
+    hreq.addHeader("Authorization", "Basic " + base64::encode(Common::asBinaryArray(user + ":" + password)));
   }
   hreq.setUrl(url);
   hreq.setBody(storeToBinaryKeyValue(req));

--- a/src/HTTP/HttpServer.cpp
+++ b/src/HTTP/HttpServer.cpp
@@ -127,22 +127,22 @@ void HttpServer::acceptLoop() {
 }
 
 bool HttpServer::authenticate(const HttpRequest& request) const {
-	if (!m_credentials.empty()) {
-		auto headerIt = request.getHeaders().find("authorization");
-		if (headerIt == request.getHeaders().end()) {
-			return false;
-		}
+  if (!m_credentials.empty()) {
+    auto headerIt = request.getHeaders().find("authorization");
+    if (headerIt == request.getHeaders().end()) {
+      return false;
+    }
 
-		if (headerIt->second.substr(0, 6) != "Basic ") {
-			return false;
-		}
+    if (headerIt->second.substr(0, 6) != "Basic ") {
+      return false;
+    }
 
-		if (headerIt->second.substr(6) != m_credentials) {
-			return false;
-		}
-	}
+    if (headerIt->second.substr(6) != m_credentials) {
+      return false;
+    }
+  }
 
-	return true;
+  return true;
 }
 
 size_t HttpServer::get_connections_count() const {

--- a/src/HTTP/HttpServer.cpp
+++ b/src/HTTP/HttpServer.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+// Copyright (c) 2014-2016 XDN developers
+// Copyright (c) 2016-2018 Karbowanec developers
+//
+// This file is part of Karbo.
+//
+// Karbo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Karbo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Karbo.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "HttpServer.h"
+#include <boost/scope_exit.hpp>
+
+#include <Common/base64.hpp>
+#include <Common/StringTools.h>
+#include <HTTP/HttpParser.h>
+#include <System/InterruptedException.h>
+#include <System/TcpStream.h>
+#include <System/Ipv4Address.h>
+
+using namespace Logging;
+
+namespace {
+	void fillUnauthorizedResponse(CryptoNote::HttpResponse& response) {
+		response.setStatus(CryptoNote::HttpResponse::STATUS_401);
+		response.addHeader("WWW-Authenticate", "Basic realm=\"RPC\"");
+		response.addHeader("Content-Type", "text/plain");
+		response.setBody("Authorization required");
+	}
+}
+
+namespace CryptoNote {
+
+HttpServer::HttpServer(System::Dispatcher& dispatcher, Logging::ILogger& log)
+  : m_dispatcher(dispatcher), workingContextGroup(dispatcher), logger(log, "HttpServer") {
+
+}
+
+void HttpServer::start(const std::string& address, uint16_t port, const std::string& user, const std::string& password) {
+  m_listener = System::TcpListener(m_dispatcher, System::Ipv4Address(address), port);
+  workingContextGroup.spawn(std::bind(&HttpServer::acceptLoop, this));
+  
+  if (!user.empty() || !password.empty()) {
+    m_credentials = base64::encode(Common::asBinaryArray(user + ":" + password));
+  }
+}
+
+void HttpServer::stop() {
+  workingContextGroup.interrupt();
+  workingContextGroup.wait();
+}
+
+void HttpServer::acceptLoop() {
+  try {
+    System::TcpConnection connection; 
+    bool accepted = false;
+
+    while (!accepted) {
+      try {
+        connection = m_listener.accept();
+        accepted = true;
+      } catch (System::InterruptedException&) {
+        throw;
+      } catch (std::exception&) {
+        // try again
+      }
+    }
+
+    m_connections.insert(&connection);
+    BOOST_SCOPE_EXIT_ALL(this, &connection) { 
+      m_connections.erase(&connection); };
+
+    workingContextGroup.spawn(std::bind(&HttpServer::acceptLoop, this));
+
+    //auto addr = connection.getPeerAddressAndPort();
+    auto addr = std::pair<System::Ipv4Address, uint16_t>(static_cast<System::Ipv4Address>(0), 0);
+    try {
+      addr = connection.getPeerAddressAndPort();
+    }
+    catch (std::runtime_error&) {
+      logger(WARNING) << "Could not get IP of connection";
+    }
+
+    logger(DEBUGGING) << "Incoming connection from " << addr.first.toDottedDecimal() << ":" << addr.second;
+
+    System::TcpStreambuf streambuf(connection);
+    std::iostream stream(&streambuf);
+    HttpParser parser;
+
+    for (;;) {
+      HttpRequest req;
+      HttpResponse resp;
+      resp.addHeader("Access-Control-Allow-Origin", "*");
+
+      parser.receiveRequest(stream, req);
+      if (authenticate(req)) {
+        processRequest(req, resp);
+      }
+      else {
+        logger(WARNING) << "Authorization required " << addr.first.toDottedDecimal() << ":" << addr.second;
+        fillUnauthorizedResponse(resp);
+      }
+
+      stream << resp;
+      stream.flush();
+
+      if (stream.peek() == std::iostream::traits_type::eof()) {
+        break;
+      }
+    }
+
+    logger(DEBUGGING) << "Closing connection from " << addr.first.toDottedDecimal() << ":" << addr.second << " total=" << m_connections.size();
+
+  } catch (System::InterruptedException&) {
+  } catch (std::exception& e) {
+    logger(DEBUGGING) << "Connection error: " << e.what();
+  }
+}
+
+bool HttpServer::authenticate(const HttpRequest& request) const {
+	if (!m_credentials.empty()) {
+		auto headerIt = request.getHeaders().find("authorization");
+		if (headerIt == request.getHeaders().end()) {
+			return false;
+		}
+
+		if (headerIt->second.substr(0, 6) != "Basic ") {
+			return false;
+		}
+
+		if (headerIt->second.substr(6) != m_credentials) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+size_t HttpServer::get_connections_count() const {
+	return m_connections.size();
+}
+
+}

--- a/src/HTTP/HttpServer.h
+++ b/src/HTTP/HttpServer.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
+//
+// This file is part of Karbo.
+//
+// Karbo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Karbo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// Copyright (c) 2014-2016 XDN developers
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Karbo.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once 
+
+#include <unordered_set>
+
+#include <HTTP/HttpRequest.h>
+#include <HTTP/HttpResponse.h>
+
+#include <System/ContextGroup.h>
+#include <System/Dispatcher.h>
+#include <System/TcpListener.h>
+#include <System/TcpConnection.h>
+#include <System/Event.h>
+
+#include <Logging/LoggerRef.h>
+
+namespace CryptoNote {
+
+class HttpServer {
+
+public:
+
+  HttpServer(System::Dispatcher& dispatcher, Logging::ILogger& log);
+
+  void start(const std::string& address, uint16_t port, const std::string& user = "", const std::string& password = "");
+  void stop();
+
+  virtual void processRequest(const HttpRequest& request, HttpResponse& response) = 0;
+  virtual size_t get_connections_count() const;
+
+protected:
+
+  System::Dispatcher& m_dispatcher;
+
+private:
+
+  void acceptLoop();
+  void connectionHandler(System::TcpConnection&& conn);
+  bool authenticate(const HttpRequest& request) const;
+
+  System::ContextGroup workingContextGroup;
+  Logging::LoggerRef logger;
+  System::TcpListener m_listener;
+  std::unordered_set<System::TcpConnection*> m_connections;
+  std::string m_credentials;
+};
+
+}

--- a/src/JsonRpcServer/JsonRpcServer.cpp
+++ b/src/JsonRpcServer/JsonRpcServer.cpp
@@ -93,6 +93,11 @@ bool JsonRpcServer::authenticate(const CryptoNote::HttpRequest& request) const {
 void JsonRpcServer::processRequest(const CryptoNote::HttpRequest& req, CryptoNote::HttpResponse& resp) {
   try {
 
+    resp.addHeader("Content-Type", "application/json");
+    resp.addHeader("Access-Control-Allow-Origin", "*");
+    resp.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    resp.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+
     if (!authenticate(req)) {
       logger(Logging::WARNING) << "Authorization required";
       resp.setStatus(HttpResponse::STATUS_401);
@@ -112,15 +117,9 @@ void JsonRpcServer::processRequest(const CryptoNote::HttpRequest& req, CryptoNot
       } catch (std::runtime_error&) {
         logger(Logging::DEBUGGING) << "Couldn't parse request: \"" << req.getBody() << "\"";
         makeJsonParsingErrorResponse(jsonRpcResponse);
-        
-        resp.addHeader("Content-Type", "application/json");
-        resp.addHeader("Access-Control-Allow-Origin", "*");
-        resp.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-        resp.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
 
         resp.setStatus(CryptoNote::HttpResponse::STATUS_200);
         resp.setBody(jsonRpcResponse.toString());
-
         return;
       }
 

--- a/src/JsonRpcServer/JsonRpcServer.cpp
+++ b/src/JsonRpcServer/JsonRpcServer.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright(c) 2014 - 2017 XDN - project developers
-// Copyright(c) 2018 - 2022 The Karbo developers
+// Copyright(c) 2018 - 2023 The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -43,71 +43,38 @@
 namespace CryptoNote {
 
 JsonRpcServer::JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup) :
+  HttpServer(sys, loggerGroup),
   m_dispatcher(sys),
   stopEvent(stopEvent),
-  logger(loggerGroup, "JsonRpcServer"),
-  m_enable_ssl(false)
+  logger(loggerGroup, "JsonRpcServer")
 {
 }
 
 JsonRpcServer::~JsonRpcServer() {
-  stop();
 }
 
-void JsonRpcServer::start(const std::string& bindAddress, uint16_t bindPort, uint16_t bindPortSSL) {
-  if (m_enable_ssl) {
-    m_workers.emplace_back(std::unique_ptr<System::RemoteContext<void>>(
-      new System::RemoteContext<void>(m_dispatcher, std::bind(&JsonRpcServer::listen_ssl, this, bindAddress, bindPortSSL)))
-    );
-  }
-
-  m_workers.emplace_back(std::unique_ptr<System::RemoteContext<void>>(
-    new System::RemoteContext<void>(m_dispatcher, std::bind(&JsonRpcServer::listen, this, bindAddress, bindPort)))
-  );
+void JsonRpcServer::start(const std::string& bindAddress, uint16_t bindPort) {
+  HttpServer::start(bindAddress, bindPort, m_rpcUser, m_rpcPassword);
 
   stopEvent.wait();
+
+  HttpServer::stop();
 }
 
-void JsonRpcServer::stop() {
-  if (m_enable_ssl) {
-    https->stop();
-  }
+void JsonRpcServer::init(const std::string& user, const std::string& password) {
+  m_rpcUser = user;
+  m_rpcPassword = password;
 
-  http->stop();
-
-  m_workers.clear();
-}
-
-void JsonRpcServer::init(const std::string& chain_file, const std::string& key_file, bool server_ssl_enable){
-  m_chain_file = chain_file;
-  m_key_file = key_file;
-  m_enable_ssl = server_ssl_enable;
-
-  http = new httplib::Server();
-
-  http->Post(".*", [this](const httplib::Request& req, httplib::Response& res) {
-    processRequest(req, res);
-  });
-
-  if (server_ssl_enable) {
-    https = new httplib::SSLServer(m_chain_file.c_str(), m_key_file.c_str());
-
-    https->Post(".*", [this](const httplib::Request& req, httplib::Response& res) {
-      processRequest(req, res);
-    });
-  }
-}
-
-void JsonRpcServer::setAuth(const std::string& user, const std::string& password) {
   if (!user.empty() || !password.empty()) {
     m_credentials = base64::encode(Common::asBinaryArray(user + ":" + password));
   }
 }
 
-bool JsonRpcServer::authenticate(const httplib::Request& request) const {
+bool JsonRpcServer::authenticate(const CryptoNote::HttpRequest& request) const {
   if (!m_credentials.empty()) {
-    auto headerIt = request.headers.find("authorization");
-    if (headerIt == request.headers.end()) {
+    auto headers = request.getHeaders();
+    auto headerIt = headers.find("authorization");
+    if (headerIt == headers.end()) {
       return false;
     }
 
@@ -123,46 +90,36 @@ bool JsonRpcServer::authenticate(const httplib::Request& request) const {
   return true;
 }
 
-void JsonRpcServer::listen(const std::string address, const uint16_t port) {
-  if (!http->listen(address.c_str(), port)) {
-    logger(Logging::WARNING) << "Could not bind service to " << address << ":" << port
-      << "\nIs another service using this address and port?\n";
-  }
-}
-
-void JsonRpcServer::listen_ssl(const std::string address, const uint16_t port) {
-  if (!https->listen(address.c_str(), port)) {
-    logger(Logging::WARNING) << "Could not bind service to " << address << ":" << port
-      << "\nIs another service using this address and port?\n";
-  }
-}
-
-void JsonRpcServer::processRequest(const httplib::Request& req, httplib::Response& resp) {
+void JsonRpcServer::processRequest(const CryptoNote::HttpRequest& req, CryptoNote::HttpResponse& resp) {
   try {
 
     if (!authenticate(req)) {
       logger(Logging::WARNING) << "Authorization required";
-      resp.status = 401;
-      resp.set_header("WWW-Authenticate", "Basic realm=\"RPC\"");
-      resp.set_content("Authorization required", "text/plain; charset=UTF-8");
+      resp.setStatus(HttpResponse::STATUS_401);
+      resp.addHeader("WWW-Authenticate", "Basic realm=\"RPC\"");
+      resp.setBody("Authorization required");
 
       return;
     }
 
-    if (req.path == "/json_rpc") {
-      std::istringstream jsonInputStream(req.body);
+    if (req.getUrl() == "/json_rpc") {
+      std::istringstream jsonInputStream(req.getBody());
       Common::JsonValue jsonRpcRequest;
       Common::JsonValue jsonRpcResponse(Common::JsonValue::OBJECT);
 
       try {
         jsonInputStream >> jsonRpcRequest;
       } catch (std::runtime_error&) {
-        logger(Logging::DEBUGGING) << "Couldn't parse request: \"" << req.body << "\"";
+        logger(Logging::DEBUGGING) << "Couldn't parse request: \"" << req.getBody() << "\"";
         makeJsonParsingErrorResponse(jsonRpcResponse);
         
-        resp.set_header("Access-Control-Allow-Origin", "*");
-        resp.status = 200;
-        resp.set_content(jsonRpcResponse.toString(), "application/json");
+        resp.addHeader("Content-Type", "application/json");
+        resp.addHeader("Access-Control-Allow-Origin", "*");
+        resp.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+        resp.addHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
+
+        resp.setStatus(CryptoNote::HttpResponse::STATUS_200);
+        resp.setBody(jsonRpcResponse.toString());
 
         return;
       }
@@ -172,17 +129,17 @@ void JsonRpcServer::processRequest(const httplib::Request& req, httplib::Respons
       std::ostringstream jsonOutputStream;
       jsonOutputStream << jsonRpcResponse;
 
-      resp.status = 200;
-      resp.set_content(jsonOutputStream.str(), "application/json");
+      resp.setStatus(CryptoNote::HttpResponse::STATUS_200);
+      resp.setBody(jsonOutputStream.str());
 
     } else {
-      logger(Logging::WARNING) << "Requested url \"" << req.path << "\" is not found";
-      resp.status = 404;
+      logger(Logging::WARNING) << "Requested url \"" << req.getUrl() << "\" is not found";
+      resp.setStatus(CryptoNote::HttpResponse::STATUS_404);
       return;
     }
   } catch (std::exception& e) {
     logger(Logging::WARNING) << "Error while processing http request: " << e.what();
-    resp.status = 500;
+    resp.setStatus(CryptoNote::HttpResponse::STATUS_500);
   }
 }
 

--- a/src/JsonRpcServer/JsonRpcServer.h
+++ b/src/JsonRpcServer/JsonRpcServer.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright(c) 2014 - 2017 XDN - project developers
-// Copyright(c) 2018 - 2022 The Karbo developers
+// Copyright(c) 2018 - 2023 The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -26,7 +26,7 @@
 #include "System/RemoteContext.h"
 #include "Logging/ILogger.h"
 #include "Logging/LoggerRef.h"
-#include "HTTP/httplib.h"
+#include "HTTP/HttpServer.h"
 
 
 namespace CryptoNote {
@@ -44,17 +44,15 @@ class TcpConnection;
 
 namespace CryptoNote {
 
-class JsonRpcServer {
+class JsonRpcServer : HttpServer {
 public:
   JsonRpcServer(System::Dispatcher& sys, System::Event& stopEvent, Logging::ILogger& loggerGroup);
   JsonRpcServer(const JsonRpcServer&) = delete;
 
   ~JsonRpcServer();
 
-  void init(const std::string& chain_file, const std::string& key_file, bool server_ssl_enable = false);
-  void setAuth(const std::string& user, const std::string& password);
-
-  void start(const std::string& bindAddress, uint16_t bindPort, uint16_t bindPortSSL);
+  void init(const std::string& user, const std::string& password);
+  void start(const std::string& bindAddress, uint16_t bindPort);
   void stop();
 
 protected:
@@ -68,25 +66,17 @@ protected:
   virtual void processJsonRpcRequest(const Common::JsonValue& req, Common::JsonValue& resp) = 0;
 
 private:
-  void processRequest(const httplib::Request& request, httplib::Response& response);
-
-  void listen(const std::string address, const uint16_t port);
-  void listen_ssl(const std::string address, const uint16_t port);
-  bool authenticate(const httplib::Request& request) const;
+  virtual void processRequest(const CryptoNote::HttpRequest& request, CryptoNote::HttpResponse& response) override;
+  bool authenticate(const CryptoNote::HttpRequest& request) const;
 
   System::Dispatcher& m_dispatcher;
   System::Event& stopEvent;
   Logging::LoggerRef logger;
-  httplib::Server* http;
-  httplib::SSLServer* https;
-
-  std::vector<std::unique_ptr<System::RemoteContext<void>>> m_workers;
-
-  std::string m_chain_file;
-  std::string m_key_file;
+  
   std::string m_credentials;
+  std::string m_rpcUser;
+  std::string m_rpcPassword;
 
-  bool m_enable_ssl;
 };
 
 } //namespace CryptoNote

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -49,27 +49,6 @@
 
 using namespace PaymentService;
 
-bool validateCertPath(const std::string& rootPath,
-                      const std::string& config_chain_file,
-                      const std::string& config_key_file,
-                      std::string& chain_file,
-                      std::string& key_file) {
-  bool res = false;
-  boost::system::error_code ec;
-  boost::filesystem::path data_dir_path(rootPath);
-  boost::filesystem::path chain_file_path(config_chain_file);
-  boost::filesystem::path key_file_path(config_key_file);
-  if (!chain_file_path.has_parent_path()) chain_file_path = data_dir_path / chain_file_path;
-  if (!key_file_path.has_parent_path()) key_file_path = data_dir_path / key_file_path;
-  if (boost::filesystem::exists(chain_file_path, ec) &&
-      boost::filesystem::exists(key_file_path, ec)) {
-        chain_file = boost::filesystem::canonical(chain_file_path).string();
-        key_file = boost::filesystem::canonical(key_file_path).string();
-        res = true;
-  }
-  return res;
-}
-
 void changeDirectory(const std::string& path) {
   if (chdir(path.c_str())) {
     throw std::runtime_error("Couldn't change directory to \'" + path + "\': " + strerror(errno));
@@ -303,6 +282,16 @@ void PaymentGateService::runRpcProxy(Logging::LoggerRef& log) {
   }
 }
 
+void PaymentGateService::runJsonRpcServer() {
+  PaymentService::PaymentServiceJsonRpcServer rpcServer(*dispatcher, *stopEvent, *service, logger);
+
+  rpcServer.init(config.gateConfiguration.m_rpcUser, config.gateConfiguration.m_rpcPassword);
+
+  rpcServer.start(config.gateConfiguration.m_bind_address, config.gateConfiguration.m_bind_port);
+
+  Logging::LoggerRef(logger, "PaymentGateService")(Logging::INFO, Logging::BRIGHT_WHITE) << "JSON-RPC server stopped, stopping wallet service...";
+}
+
 void PaymentGateService::runWalletService(const CryptoNote::Currency& currency, CryptoNote::INode& node) {
   PaymentService::WalletConfiguration walletConfiguration{
     config.gateConfiguration.containerFile,
@@ -329,33 +318,7 @@ void PaymentGateService::runWalletService(const CryptoNote::Currency& currency, 
     }
   } else {
 
-    PaymentService::PaymentServiceJsonRpcServer rpcServer(*dispatcher, *stopEvent, *service, logger);
-
-    bool rpc_run_ssl = false;
-    std::string rpc_chain_file = "";
-    std::string rpc_key_file = "";
-
-    if (config.gateConfiguration.m_enable_ssl) {
-      if (validateCertPath(config.coreConfig.configFolder,
-        config.gateConfiguration.m_chain_file,
-        config.gateConfiguration.m_key_file,
-        rpc_chain_file,
-        rpc_key_file)){
-        rpc_run_ssl = true;
-      } else {
-        Logging::LoggerRef(logger, "PaymentGateService")(Logging::ERROR, Logging::BRIGHT_RED) << "Start JSON-RPC SSL server was canceled because certificate file(s) could not be found" << std::endl;
-      }
-    }
-
-    rpcServer.init(rpc_chain_file, rpc_key_file, rpc_run_ssl);
-
-    rpcServer.setAuth(config.gateConfiguration.m_rpcUser, config.gateConfiguration.m_rpcPassword);
-
-    rpcServer.start(config.gateConfiguration.m_bind_address,
-                    config.gateConfiguration.m_bind_port,
-                    config.gateConfiguration.m_bind_port_ssl);
-
-    Logging::LoggerRef(logger, "PaymentGateService")(Logging::INFO, Logging::BRIGHT_WHITE) << "JSON-RPC server stopped, stopping wallet service...";
+    runJsonRpcServer();
 
     try {
       service->saveWallet();

--- a/src/PaymentGateService/PaymentGateService.cpp
+++ b/src/PaymentGateService/PaymentGateService.cpp
@@ -287,6 +287,8 @@ void PaymentGateService::runJsonRpcServer() {
 
   rpcServer.init(config.gateConfiguration.m_rpcUser, config.gateConfiguration.m_rpcPassword);
 
+  Logging::LoggerRef(logger, "PaymentGateService")(Logging::INFO, Logging::BRIGHT_WHITE) << "Starting JSON-RPC server...";
+
   rpcServer.start(config.gateConfiguration.m_bind_address, config.gateConfiguration.m_bind_port);
 
   Logging::LoggerRef(logger, "PaymentGateService")(Logging::INFO, Logging::BRIGHT_WHITE) << "JSON-RPC server stopped, stopping wallet service...";

--- a/src/PaymentGateService/PaymentGateService.h
+++ b/src/PaymentGateService/PaymentGateService.h
@@ -48,6 +48,7 @@ private:
   void runRpcProxy(Logging::LoggerRef& log);
   
   void runWalletService(const CryptoNote::Currency& currency, CryptoNote::INode& node);
+  void runJsonRpcServer();
 
   System::Dispatcher* dispatcher;
   System::Event* stopEvent;

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -46,6 +46,7 @@ Configuration::Configuration() {
   printAddresses = false;
   logLevel = Logging::INFO;
   m_bind_address = "";
+  m_bind_port = 0;
   m_rpcUser = "";
   m_rpcPassword = "";
   secretViewKey = "";

--- a/src/PaymentGateService/PaymentServiceConfiguration.cpp
+++ b/src/PaymentGateService/PaymentServiceConfiguration.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014 - 2017 XDN - project developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// Copyright (c) 2018-2019 The Karbo developers
+// Copyright (c) 2018-2023 The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -46,16 +46,11 @@ Configuration::Configuration() {
   printAddresses = false;
   logLevel = Logging::INFO;
   m_bind_address = "";
-  m_bind_port = 0;
-  m_bind_port_ssl = 0;
   m_rpcUser = "";
   m_rpcPassword = "";
   secretViewKey = "";
   secretSpendKey = "";
   mnemonicSeed = "";
-  m_enable_ssl = false;
-  m_chain_file = "";
-  m_key_file = "";
   scanHeight = 0;
 }
 
@@ -63,12 +58,8 @@ void Configuration::initOptions(po::options_description& desc) {
   desc.add_options()
       ("bind-address", po::value<std::string>()->default_value("127.0.0.1"), "payment service bind address")
       ("bind-port", po::value<uint16_t>()->default_value((uint16_t) CryptoNote::GATE_RPC_DEFAULT_PORT), "payment service bind port")
-      ("bind-port-ssl", po::value<uint16_t>()->default_value((uint16_t) CryptoNote::GATE_RPC_DEFAULT_SSL_PORT), "payment service bind port ssl")
       ("rpc-user", po::value<std::string>(), "Username to use with the RPC server. If empty, no server authorization will be done")
       ("rpc-password", po::value<std::string>(), "Password to use with the RPC server. If empty, no server authorization will be done")
-      ("rpc-ssl-enable", po::bool_switch(), "Enable SSL for RPC service")
-      ("rpc-chain-file", po::value<std::string>()->default_value(std::string(CryptoNote::RPC_DEFAULT_CHAIN_FILE)), "SSL chain file")
-      ("rpc-key-file", po::value<std::string>()->default_value(std::string(CryptoNote::RPC_DEFAULT_KEY_FILE)), "SSL key file")
       ("container-file,w", po::value<std::string>(), "container file")
       ("container-password,p", po::value<std::string>(), "container password")
       ("change-password", po::value<std::string>(), "change container password and exit")
@@ -138,28 +129,12 @@ void Configuration::init(const po::variables_map& options) {
     m_bind_port = options["bind-port"].as<uint16_t>();
   }
 
-  if (options.count("bind-port-ssl") != 0 && (!options["bind-port-ssl"].defaulted() || m_bind_port_ssl == 0)) {
-    m_bind_port_ssl = options["bind-port-ssl"].as<uint16_t>();
-  }
-
   if (options.count("rpc-user") != 0) {
     m_rpcUser = options["rpc-user"].as<std::string>();
   }
 
   if (options.count("rpc-password") != 0) {
     m_rpcPassword = options["rpc-password"].as<std::string>();
-  }
-
-  if (options["rpc-ssl-enable"].as<bool>()){
-    m_enable_ssl = true;
-  }
-
-  if (options.count("rpc-chain-file") != 0 && (!options["rpc-chain-file"].defaulted() || m_chain_file.empty())) {
-    m_chain_file = options["rpc-chain-file"].as<std::string>();
-  }
-
-  if (options.count("rpc-key-file") != 0 && (!options["rpc-key-file"].defaulted() || m_key_file.empty())) {
-    m_key_file = options["rpc-key-file"].as<std::string>();
   }
 
   if (options.count("container-file") != 0) {
@@ -215,12 +190,11 @@ void Configuration::init(const po::variables_map& options) {
     if (containerFile.empty() && containerPassword.empty()) {
       throw ConfigurationError("Both container-file and container-password parameters are required");
     }
-	if (containerPassword.empty()) {
-		if (pwd_container.read_password()) {
-			containerPassword = pwd_container.password();
-		}
-	}
-
+    if (containerPassword.empty()) {
+      if (pwd_container.read_password()) {
+        containerPassword = pwd_container.password();
+      }
+    }
   }
 }
 

--- a/src/PaymentGateService/PaymentServiceConfiguration.h
+++ b/src/PaymentGateService/PaymentServiceConfiguration.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014 - 2017 XDN - project developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// Copyright (c) 2016-2019 The Karbo developers
+// Copyright (c) 2016-2023 The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -47,12 +47,8 @@ struct Configuration {
 
   std::string m_bind_address;
   uint16_t m_bind_port;
-  uint16_t m_bind_port_ssl;
   std::string m_rpcUser;
   std::string m_rpcPassword;
-  bool m_enable_ssl;
-  std::string m_chain_file;
-  std::string m_key_file;
 
   std::string containerFile;
   std::string containerPassword;

--- a/src/Platform/Windows/System/Dispatcher.cpp
+++ b/src/Platform/Windows/System/Dispatcher.cpp
@@ -93,7 +93,7 @@ Dispatcher::Dispatcher() {
 }
 
 Dispatcher::~Dispatcher() {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   for (NativeContext* context = contextGroup.firstContext; context != nullptr; context = context->groupNext) {
     interrupt(context);
   }
@@ -120,7 +120,7 @@ Dispatcher::~Dispatcher() {
 }
 
 void Dispatcher::clear() {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   while (firstReusableContext != nullptr) {
     void* fiber = firstReusableContext->fiber;
     firstReusableContext = firstReusableContext->next;
@@ -129,7 +129,7 @@ void Dispatcher::clear() {
 }
 
 void Dispatcher::dispatch() {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   NativeContext* context;
   for (;;) {
 
@@ -192,7 +192,7 @@ void Dispatcher::dispatch() {
 }
 
 NativeContext* Dispatcher::getCurrentContext() const {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   return currentContext;
 }
 
@@ -201,7 +201,7 @@ void Dispatcher::interrupt() {
 }
 
 void Dispatcher::interrupt(NativeContext* context) {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   assert(context != nullptr);
   if (!context->interrupted) {
     if (context->interruptProcedure != nullptr) {
@@ -223,7 +223,7 @@ bool Dispatcher::interrupted() {
 }
 
 void Dispatcher::pushContext(NativeContext* context) {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   assert(context != nullptr);
   if (context->inExecutionQueue) {
     return;
@@ -255,7 +255,7 @@ void Dispatcher::remoteSpawn(std::function<void()>&& procedure) {
 }
 
 void Dispatcher::spawn(std::function<void()>&& procedure) {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   NativeContext* context = &getReusableContext();
   if (contextGroup.firstContext != nullptr) {
     context->groupPrev = contextGroup.lastContext;
@@ -276,7 +276,7 @@ void Dispatcher::spawn(std::function<void()>&& procedure) {
 }
 
 void Dispatcher::yield() {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   for (;;) {
     LARGE_INTEGER frequency;
     LARGE_INTEGER ticks;
@@ -331,7 +331,7 @@ void Dispatcher::yield() {
 }
 
 void Dispatcher::addTimer(uint64_t time, NativeContext* context) {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   timers.insert(std::make_pair(time, context));
 }
 
@@ -363,7 +363,7 @@ void Dispatcher::pushReusableContext(NativeContext& context) {
 }
 
 void Dispatcher::interruptTimer(uint64_t time, NativeContext* context) {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   if (context->inExecutionQueue) {
     return;
   }
@@ -379,7 +379,7 @@ void Dispatcher::interruptTimer(uint64_t time, NativeContext* context) {
 }
 
 void Dispatcher::contextProcedure() {
-  assert(GetCurrentThreadId() == threadId);
+  //assert(GetCurrentThreadId() == threadId);
   assert(firstReusableContext == nullptr);
   NativeContext context;
   context.interrupted = false;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2696,10 +2696,7 @@ int main(int argc, char* argv[]) {
       wrpc.send_stop_signal();
     });
 
-    bool enable_ssl;
     std::string bind_address;
-    std::string bind_address_ssl;
-    std::string ssl_info;
     wrpc.getServerConf(bind_address);
     logger(INFO) << "Starting wallet rpc server on address " << bind_address;
     wrpc.run();

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2542,7 +2542,6 @@ int main(int argc, char* argv[]) {
   Logging::LoggerManager logManager;
   Logging::LoggerRef logger(logManager, "simplewallet");
   System::Dispatcher dispatcher;
-  System::Event m_stopComplete(dispatcher);
 
   po::variables_map vm;
 
@@ -2686,32 +2685,24 @@ int main(int argc, char* argv[]) {
       return 1;
     }
 
-    Tools::wallet_rpc_server wrpc(logManager, *wallet, *node, currency, walletFileName);
+    Tools::wallet_rpc_server wrpc(dispatcher, logManager, *wallet, *node, currency, walletFileName);
 
     if (!wrpc.init(vm)) {
       logger(ERROR, BRIGHT_RED) << "Failed to initialize wallet rpc server";
       return 1;
     }
 
-    Tools::SignalHandler::install([&m_stopComplete, &dispatcher, &wrpc, &wallet] {
-      wrpc.stop();
-
-      dispatcher.remoteSpawn([&] {
-        m_stopComplete.set();
-      });
-
+    Tools::SignalHandler::install([&wrpc, &wallet] {
+      wrpc.send_stop_signal();
     });
 
     bool enable_ssl;
     std::string bind_address;
     std::string bind_address_ssl;
     std::string ssl_info;
-    wrpc.getServerConf(bind_address, bind_address_ssl, enable_ssl);
-    if (enable_ssl) ssl_info += std::string(", SSL on address ") + bind_address_ssl;
-    logger(INFO) << "Starting wallet rpc server on address " << bind_address << ssl_info;
+    wrpc.getServerConf(bind_address);
+    logger(INFO) << "Starting wallet rpc server on address " << bind_address;
     wrpc.run();
-
-    m_stopComplete.wait();
 
     logger(INFO) << "Stopped wallet rpc server";
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -50,8 +50,6 @@
 #include "Logging/LoggerRef.h"
 #include "Logging/LoggerManager.h"
 #include "System/Dispatcher.h"
-#include "System/Event.h"
-#include "System/RemoteContext.h"
 #include "System/Ipv4Address.h"
 
 using namespace Logging;

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -51,10 +51,6 @@ const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_rpc_user 
   { "rpc-user"     , "Username to use with the RPC server. If empty, no server authorization will be done.", "" };
 const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_rpc_password = 
   { "rpc-password" , "Password to use with the RPC server. If empty, no server authorization will be done.", "" };
-const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_chain_file =
-  { "rpc-chain-file" , "SSL chain file", RPC_DEFAULT_CHAIN_FILE };
-const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_key_file =
-  { "rpc-key-file" , "SSL key file", RPC_DEFAULT_KEY_FILE };
 
 void wallet_rpc_server::init_options(boost::program_options::options_description& desc)
 {
@@ -62,8 +58,6 @@ void wallet_rpc_server::init_options(boost::program_options::options_description
   command_line::add_arg(desc, arg_rpc_bind_port);
   command_line::add_arg(desc, arg_rpc_user);
   command_line::add_arg(desc, arg_rpc_password);
-  command_line::add_arg(desc, arg_chain_file);
-  command_line::add_arg(desc, arg_key_file);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
@@ -84,11 +78,6 @@ wallet_rpc_server::wallet_rpc_server(
   m_currency(currency),
   m_walletFilename(walletFilename)
 {
-}
-
-//------------------------------------------------------------------------------------------------------------------------------
-
-wallet_rpc_server::~wallet_rpc_server() {  
 }
 
 //------------------------------------------------------------------------------------------------------------------------------

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2016, XDN developers
 // Copyright (c) 2014-2016, The Monero Project
-// Copyright (c) 2016-2022, Karbo developers
+// Copyright (c) 2016-2023, Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -45,12 +45,8 @@ namespace Tools {
 
 const command_line::arg_descriptor<uint16_t>    wallet_rpc_server::arg_rpc_bind_port =
   { "rpc-bind-port", "Starts wallet as RPC server for wallet operations, sets bind port for server.", WALLET_RPC_DEFAULT_PORT, true };
-const command_line::arg_descriptor<uint16_t>    wallet_rpc_server::arg_rpc_bind_ssl_port =
-  { "rpc-bind-ssl-port", "Starts wallet as RPC server for wallet operations, sets bind port ssl for server.", WALLET_RPC_DEFAULT_SSL_PORT };
 const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_rpc_bind_ip = 
   { "rpc-bind-ip"  , "Specify IP to bind RPC server to.", "127.0.0.1" };
-const command_line::arg_descriptor<bool>    wallet_rpc_server::arg_rpc_bind_ssl_enable =
-  { "rpc-bind-ssl-enable", "Enable SSL for RPC service", false, true };
 const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_rpc_user = 
   { "rpc-user"     , "Username to use with the RPC server. If empty, no server authorization will be done.", "" };
 const command_line::arg_descriptor<std::string> wallet_rpc_server::arg_rpc_password = 
@@ -64,8 +60,6 @@ void wallet_rpc_server::init_options(boost::program_options::options_description
 {
   command_line::add_arg(desc, arg_rpc_bind_ip);
   command_line::add_arg(desc, arg_rpc_bind_port);
-  command_line::add_arg(desc, arg_rpc_bind_ssl_port);
-  command_line::add_arg(desc, arg_rpc_bind_ssl_enable);
   command_line::add_arg(desc, arg_rpc_user);
   command_line::add_arg(desc, arg_rpc_password);
   command_line::add_arg(desc, arg_chain_file);
@@ -75,17 +69,20 @@ void wallet_rpc_server::init_options(boost::program_options::options_description
 //------------------------------------------------------------------------------------------------------------------------------
 
 wallet_rpc_server::wallet_rpc_server(
+  System::Dispatcher& dispatcher,
   Logging::ILogger& log,
   CryptoNote::IWalletLegacy& w,
   CryptoNote::INode& n,
   CryptoNote::Currency& currency,
   const std::string& walletFilename) :
+  HttpServer(dispatcher, log),
   logger(log, "WalletRpc"),
+  m_dispatcher(dispatcher),
+  m_stopComplete(dispatcher),
   m_wallet(w),
   m_node(n),
   m_currency(currency),
-  m_walletFilename(walletFilename),
-  m_run_ssl(false)
+  m_walletFilename(walletFilename)
 {
 }
 
@@ -98,47 +95,20 @@ wallet_rpc_server::~wallet_rpc_server() {
 
 bool wallet_rpc_server::run()
 {
-  if (m_run_ssl) {
-    m_workers.push_back(std::thread(std::bind(&wallet_rpc_server::listen_ssl, this, m_bind_ip, m_port_ssl)));
-  }
-
-  m_workers.push_back(std::thread(std::bind(&wallet_rpc_server::listen, this, m_bind_ip, m_port)));
-
+  start(m_bind_ip, m_port, m_rpcUser, m_rpcPassword);
+  m_stopComplete.wait();
   return true;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
 
-void wallet_rpc_server::stop() {
-  if (m_run_ssl) {
-    https->stop();
-  }
-
-  http->stop();
-
-  for (auto& th : m_workers) {
-    if (th.joinable()) {
-      th.join();
-    }
-  }
-
-  m_workers.clear();
-}
-
-//------------------------------------------------------------------------------------------------------------------------------
-
-void wallet_rpc_server::listen(const std::string address, const uint16_t port) {
-  if (!http->listen(address.c_str(), port)) {
-    logger(Logging::ERROR) << "Could not bind service to " << address << ":" << port
-      << "\nIs another service using this address and port?\n";
-  }
-}
-
-void wallet_rpc_server::listen_ssl(const std::string address, const uint16_t port) {
-  if (!https->listen(address.c_str(), port)) {
-    logger(Logging::ERROR) << "Could not bind service to " << address << ":" << port
-      << "\nIs another service using this address and port?\n";
-  }
+void wallet_rpc_server::send_stop_signal() {
+  m_dispatcher.remoteSpawn([this]
+  {
+    std::cout << "wallet_rpc_server::send_stop_signal()" << std::endl;
+    stop();
+    m_stopComplete.set();
+  });
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
@@ -147,12 +117,8 @@ bool wallet_rpc_server::handle_command_line(const boost::program_options::variab
 {
   m_bind_ip        = command_line::get_arg(vm, arg_rpc_bind_ip);
   m_port           = command_line::get_arg(vm, arg_rpc_bind_port);
-  m_port_ssl       = command_line::get_arg(vm, arg_rpc_bind_ssl_port);
-  m_enable_ssl     = command_line::get_arg(vm, arg_rpc_bind_ssl_enable);
   m_rpcUser        = command_line::get_arg(vm, arg_rpc_user);
   m_rpcPassword    = command_line::get_arg(vm, arg_rpc_password);
-  m_chain_file     = command_line::get_arg(vm, arg_chain_file);
-  m_key_file       = command_line::get_arg(vm, arg_key_file);
   return true;
 }
 //------------------------------------------------------------------------------------------------------------------------------
@@ -160,41 +126,10 @@ bool wallet_rpc_server::handle_command_line(const boost::program_options::variab
 bool wallet_rpc_server::init(const boost::program_options::variables_map& vm)
 {
   boost::filesystem::path data_dir_path(boost::filesystem::current_path());
-  boost::filesystem::path chain_file_path(m_chain_file);
-  boost::filesystem::path key_file_path(m_key_file);
   if (!handle_command_line(vm))
   {
     logger(Logging::ERROR) << "Failed to process command line in wallet_rpc_server";
     return false;
-  }
-  else {
-    boost::system::error_code ec;
-    if (!chain_file_path.has_parent_path()) chain_file_path = data_dir_path / chain_file_path;
-    if (!key_file_path.has_parent_path()) key_file_path = data_dir_path / key_file_path;
-    if (m_enable_ssl) {
-      if (boost::filesystem::exists(chain_file_path, ec) &&
-          boost::filesystem::exists(key_file_path, ec)) {
-        m_run_ssl = true;
-      }
-      else
-      {
-        logger((Logging::Level) ERROR, BRIGHT_RED) << "Starting RPC SSL server was canceled because certificate file(s) could not be found" << std::endl;
-      }
-    }
-  }
-
-  http = new httplib::Server();
-
-  http->Post(".*", [this](const httplib::Request& req, httplib::Response& res) {
-    processRequest(req, res);
-  });
-
-  if (m_run_ssl) {
-    https = new httplib::SSLServer(boost::filesystem::canonical(chain_file_path).string().c_str(), boost::filesystem::canonical(key_file_path).string().c_str());
-
-    https->Post(".*", [this](const httplib::Request& req, httplib::Response& res) {
-      processRequest(req, res);
-    });
   }
 
   if (!m_rpcUser.empty() || !m_rpcPassword.empty()) {
@@ -206,23 +141,21 @@ bool wallet_rpc_server::init(const boost::program_options::variables_map& vm)
 
 //------------------------------------------------------------------------------------------------------------------------------
 
-void wallet_rpc_server::getServerConf(std::string &bind_address, std::string &bind_address_ssl, bool &enable_ssl) {
+void wallet_rpc_server::getServerConf(std::string &bind_address) {
   bind_address = m_bind_ip + ":" + std::to_string(m_port);
-  bind_address_ssl = m_bind_ip + ":" + std::to_string(m_port_ssl);
-  enable_ssl = m_enable_ssl;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
 
-void wallet_rpc_server::processRequest(const httplib::Request& request, httplib::Response& response)
+void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest& request, CryptoNote::HttpResponse& response)
 {
   using namespace CryptoNote::JsonRpc;
 
   if (!authenticate(request)) {
     logger(WARNING) << "Authorization required";
-    response.status = 401;
-    response.set_header("WWW-Authenticate", "Basic realm=\"RPC\"");
-    response.set_content("Authorization required", "text/plain; charset=UTF-8");
+    response.setStatus(HttpResponse::STATUS_401);
+    response.addHeader("WWW-Authenticate", "Basic realm=\"RPC\"");
+    response.setBody("Authorization required");
 
     return;
   }
@@ -232,7 +165,7 @@ void wallet_rpc_server::processRequest(const httplib::Request& request, httplib:
 
   try
   {
-    jsonRequest.parseRequest(request.body);
+    jsonRequest.parseRequest(request.getBody());
     jsonResponse.setId(jsonRequest.getId());
 
     static const std::unordered_map<std::string, JsonMemberMethod> s_methods =
@@ -276,15 +209,17 @@ void wallet_rpc_server::processRequest(const httplib::Request& request, httplib:
     jsonResponse.setError(JsonRpcError(WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR, e.what()));
   }
 
-  response.set_content(jsonResponse.getBody(), "application/json");
+  response.addHeader("Content-Type", "application/json");
+  response.setBody(jsonResponse.getBody());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
 
-bool wallet_rpc_server::authenticate(const httplib::Request& request) const {
+bool wallet_rpc_server::authenticate(const CryptoNote::HttpRequest& request) const {
   if (!m_credentials.empty()) {
-    auto headerIt = request.headers.find("authorization");
-    if (headerIt == request.headers.end()) {
+    auto headers = request.getHeaders();
+    auto headerIt = headers.find("authorization");
+    if (headerIt == headers.end()) {
       return false;
     }
 

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -44,14 +44,10 @@ public:
     CryptoNote::Currency& currency,
     const std::string& walletFilename);
 
-  ~wallet_rpc_server();
-
   static const command_line::arg_descriptor<uint16_t>    arg_rpc_bind_port;
   static const command_line::arg_descriptor<std::string> arg_rpc_bind_ip;
   static const command_line::arg_descriptor<std::string> arg_rpc_user;
   static const command_line::arg_descriptor<std::string> arg_rpc_password;
-  static const command_line::arg_descriptor<std::string> arg_chain_file;
-  static const command_line::arg_descriptor<std::string> arg_key_file;
 
   static void init_options(boost::program_options::options_description& desc);
   bool init(const boost::program_options::variables_map& vm);


### PR DESCRIPTION
Due to httplib's conflict with our dispatcher causing crashes on some RPC methods as a quick solution restore HttpServer in wallet RPC.

Older HttpServer and HttpClient without SSL support were taken as it's not needed for their use cases and doesn't work well. HttpClient is not used anywhere, it was just brought back together with HttpServer just in case.