### PR TITLE
Re-impl rpc counter

### DIFF
--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -310,7 +310,7 @@ void RpcServer::listen_ssl(const std::string address, const uint16_t port) {
 }
 
 size_t RpcServer::getRpcConnectionsCount() {
-  return 0; // Not implemented
+  return http->connecions_count() + https->connecions_count();
 }
 
 void RpcServer::processRequest(const httplib::Request& request, httplib::Response& response) {


### PR DESCRIPTION
On this request was re-impl rcp counter for show count of connection for node.

Last block hash: 58d9b11aeba570df08bb74a59731782edae1cea3f28607b666fd122893ba34d7
Difficulty: 4860000
Alt. blocks: 0
Total transactions in network: 753845
Transactions in pool: 0
Connections:
    RPC: 37

https://noda.pp.ua:32448/