### PR TITLE
Add walletd RPC method hasAddress

### DIFF
--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2018-2019, Karbo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -151,6 +151,8 @@ public:
 
   virtual size_t getAddressCount() const = 0;
   virtual std::string getAddress(size_t index) const = 0;
+  virtual bool isMyAddress(const std::string& address) const = 0;
+
   virtual AccountPublicAddress getAccountPublicAddress(size_t index) const = 0;
   virtual KeyPair getAddressSpendKey(size_t index) const = 0;
   virtual KeyPair getAddressSpendKey(const std::string& address) const = 0;

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// Copyright (c) 2018-2019 The Cash2 developers
-// Copyright (c) 2018-2019 The Karbo developers
+// Copyright (c) 2018-2019, The Cash2 developers
+// Copyright (c) 2021-2023, The Talleo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -154,6 +155,16 @@ void DeleteAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
 }
 
 void DeleteAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
+}
+
+void HasAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
+  if (!serializer(address, "address")) {
+    throw RequestSerializationError();
+  }
+}
+
+void HasAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
+  serializer(isOurs, "isOurs");
 }
 
 void GetSpendKeys::Request::serialize(CryptoNote::ISerializer& serializer) {

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -200,6 +200,20 @@ struct DeleteAddress {
   };
 };
 
+struct HasAddress {
+  struct Request {
+    std::string address;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+
+  struct Response {
+    bool isOurs;
+
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+};
+
 struct GetSpendKeys {
   struct Request {
     std::string address;

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// Copyright (c) 2018-2019 The Cash2 developers
-// Copyright (c) 2018-2019 The Karbo developers
+// Copyright (c) 2018-2019, The Cash2 developers
+// Copyright (c) 2021-2023, The Talleo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -43,6 +44,7 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher* sys
   handlers.emplace("createAddress", jsonHandler<CreateAddress::Request, CreateAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateAddress, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("createAddressList", jsonHandler<CreateAddressList::Request, CreateAddressList::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateAddressList, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("deleteAddress", jsonHandler<DeleteAddress::Request, DeleteAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleDeleteAddress, this, std::placeholders::_1, std::placeholders::_2)));
+  handlers.emplace("hasAddress", jsonHandler<HasAddress::Request, HasAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleHasAddress, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getSpendKeys", jsonHandler<GetSpendKeys::Request, GetSpendKeys::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetSpendKeys, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getBalance", jsonHandler<GetBalance::Request, GetBalance::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetBalance, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getBlockHashes", jsonHandler<GetBlockHashes::Request, GetBlockHashes::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetBlockHashes, this, std::placeholders::_1, std::placeholders::_2)));
@@ -162,6 +164,10 @@ std::error_code PaymentServiceJsonRpcServer::handleCreateAddressList(const Creat
 
 std::error_code PaymentServiceJsonRpcServer::handleDeleteAddress(const DeleteAddress::Request& request, DeleteAddress::Response& response) {
   return service.deleteAddress(request.address);
+}
+
+std::error_code PaymentServiceJsonRpcServer::handleHasAddress(const HasAddress::Request& request, HasAddress::Response& response) {
+  return service.hasAddress(request.address, response.isOurs);
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleGetSpendKeys(const GetSpendKeys::Request& request, GetSpendKeys::Response& response) {

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.h
@@ -1,7 +1,8 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// Copyright (c) 2018-2019 The Cash2 developers
-// Copyright (c) 2018-2022 The Karbo developers
+// Copyright (c) 2018-2019, The Cash2 developers
+// Copyright (c) 2021-2023, The Talleo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -80,6 +81,7 @@ private:
   std::error_code handleCreateAddress(const CreateAddress::Request& request, CreateAddress::Response& response);
   std::error_code handleCreateAddressList(const CreateAddressList::Request& request, CreateAddressList::Response& response);
   std::error_code handleDeleteAddress(const DeleteAddress::Request& request, DeleteAddress::Response& response);
+  std::error_code handleHasAddress(const HasAddress::Request& request, HasAddress::Response& response);
   std::error_code handleGetSpendKeys(const GetSpendKeys::Request& request, GetSpendKeys::Response& response);
   std::error_code handleGetBalance(const GetBalance::Request& request, GetBalance::Response& response);
   std::error_code handleGetBlockHashes(const GetBlockHashes::Request& request, GetBlockHashes::Response& response);

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -1,7 +1,8 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
 // Copyright (c) 2018-2019 The Cash2 developers
-// Copyright (c) 2016-2022, Karbo developers
+// Copyright (c) 2021-2023, The Talleo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -837,6 +838,28 @@ std::error_code WalletService::deleteAddress(const std::string& address) {
   }
 
   logger(Logging::DEBUGGING) << "Address " << address << " successfully deleted";
+  return std::error_code();
+}
+
+std::error_code WalletService::hasAddress(const std::string& address, bool& isOurs) {
+  try {
+    System::EventLock lk(readyEvent);
+
+    logger(Logging::DEBUGGING) << "Has address request came";
+
+    isOurs = wallet.isMyAddress(address);
+    if (!isOurs) {
+      logger(Logging::DEBUGGING, Logging::BRIGHT_YELLOW) << "Address " << address << " doesn't exist in container";
+      //return make_error_code(CryptoNote::error::WalletServiceErrorCode::OBJECT_NOT_FOUND);
+    } else {
+      logger(Logging::DEBUGGING) << "Address " << address << " exists in container";
+    }
+  }
+  catch (std::system_error& x) {
+    logger(Logging::DEBUGGING, Logging::BRIGHT_YELLOW) << "Error while checking if address exists in container: " << x.what();
+    return x.code();
+  }
+
   return std::error_code();
 }
 

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -1,7 +1,8 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2018, The TurtleCoin Developers
-// Copyright (c) 2018-2019 The Cash2 developers
-// Copyright (c) 2016-2019 The Karbo developers
+// Copyright (c) 2018-2019, The Cash2 developers
+// Copyright (c) 2021-2023, The Talleo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -82,6 +83,7 @@ public:
   std::error_code createTrackingAddress(const std::string& spendPublicKeyText, std::string& address);
   std::error_code createTrackingAddress(const std::string& spendPublicKeyText, const uint32_t scanHeight, std::string& address);
   std::error_code deleteAddress(const std::string& address);
+  std::error_code hasAddress(const std::string& address, bool& isOurs);
   std::error_code getSpendkeys(const std::string& address, std::string& publicSpendKeyText, std::string& secretSpendKeyText);
   std::error_code getBalance(const std::string& address, uint64_t& availableBalance, uint64_t& lockedAmount);
   std::error_code getBalance(uint64_t& availableBalance, uint64_t& lockedAmount);

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2012-2017, The CryptoNote developers, The Bytecoin developers
-// Copyright (c) 2018-2019, Karbo developers
+// Copyright (c) 2016-2024, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -60,6 +60,7 @@ public:
   virtual size_t getAddressCount() const override;
   virtual std::string getAddress(size_t index) const override;
   virtual AccountPublicAddress getAccountPublicAddress(size_t index) const override;
+  virtual bool isMyAddress(const std::string& address) const override;
   virtual KeyPair getAddressSpendKey(size_t index) const override;
   virtual KeyPair getAddressSpendKey(const std::string& address) const override;
   virtual KeyPair getViewKey() const override;
@@ -369,7 +370,6 @@ protected:
   void filterOutTransactions(WalletTransactions& transactions, WalletTransfers& transfers, std::function<bool (const WalletTransaction&)>&& pred) const;
   void initBlockchain(const Crypto::PublicKey& viewPublicKey);
   CryptoNote::AccountPublicAddress getChangeDestination(const std::string& changeDestinationAddress, const std::vector<std::string>& sourceAddresses) const;
-  bool isMyAddress(const std::string& address) const;
 
   void deleteContainerFromUnlockTransactionJobs(const ITransfersContainer* container);
   std::vector<size_t> deleteTransfersForAddress(const std::string& address, std::vector<size_t>& deletedTransactions);


### PR DESCRIPTION
Returns bool `isOurs`.

Example Request:

```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "hasAddress",
  "params": {
     "address":"Kdev1L9V5ow3cdKNqDpLcFFxZCqu5W2GE9xMKewsB2pUXWxcXvJaUWHcSrHuZw91eYfQFzRtGfTemReSSMN4kE445i6Etb31"
  }
}
```
Response:
```
{
    "id": "test",
    "jsonrpc": "2.0",
    "result": {
        "isOurs": true
    }
}
```