### PR TITLE
Removed extension when force save address (SimpleWallet.cpp)

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2430,7 +2430,9 @@ bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::save_address_to_file(const std::vector<std::string> &args/* = std::vector<std::string>()*/) {
-  std::string walletAddressFile = prepareWalletAddressFilename(m_wallet_file_arg.empty() ? m_generate_new : m_wallet_file_arg);
+  std::string walletAddressFile = prepareWalletAddressFilename(m_wallet_file_arg.empty() ?
+                                                               m_generate_new :
+                                                               Common::RemoveExtension(m_wallet_file_arg));
   boost::system::error_code ignore;
   if (boost::filesystem::exists(walletAddressFile, ignore)) {
     fail_msg_writer() << "Address file already exists: " + walletAddressFile;


### PR DESCRIPTION
If there is a need to save the wallet address to a file, as if it was saved during the creation of the wallet for the first time, the address was previously given with the suffix 'wallet', without cutting this part of the file name. In this change, the cutting is still performed and the file name remains as before, if really need to save a file with the wallet address.