### PR TITLE
Return emission as a string in RPC

### DIFF
--- a/include/BlockchainExplorerData.h
+++ b/include/BlockchainExplorerData.h
@@ -159,7 +159,7 @@ struct BlockDetails {
   uint64_t baseReward = 0;
   uint64_t blockSize = 0;
   uint64_t transactionsCumulativeSize = 0;
-  uint64_t alreadyGeneratedCoins = 0;
+  std::string alreadyGeneratedCoins;
   uint64_t alreadyGeneratedTransactions = 0;
   uint64_t sizeMedian = 0;
   uint64_t effectiveSizeMedian = 0;

--- a/src/BlockchainExplorer/BlockchainExplorerDataBuilder.cpp
+++ b/src/BlockchainExplorer/BlockchainExplorerDataBuilder.cpp
@@ -22,6 +22,7 @@
 #include <boost/range/combine.hpp>
 
 #include "Common/StringTools.h"
+#include "Common/FormatTools.h"
 #include "CryptoNoteCore/CryptoNoteFormatUtils.h"
 #include "CryptoNoteCore/CryptoNoteBasicImpl.h"
 #include "CryptoNoteCore/CryptoNoteTools.h"
@@ -150,10 +151,12 @@ bool BlockchainExplorerDataBuilder::fillBlockDetails(const Block &block, BlockDe
   size_t minerTxBlobSize = getObjectBinarySize(block.baseTransaction);
   blockDetails.blockSize = blokBlobSize + blockDetails.transactionsCumulativeSize - minerTxBlobSize;
 
-  if (!m_core.getAlreadyGeneratedCoins(hash, blockDetails.alreadyGeneratedCoins)) {
+  uint64_t alreadyGeneratedCoins = 0;
+  if (!m_core.getAlreadyGeneratedCoins(hash, alreadyGeneratedCoins)) {
     return false;
   }
-
+  blockDetails.alreadyGeneratedCoins = Common::Format::formatAmount(alreadyGeneratedCoins);
+ 
   if (!m_core.getGeneratedTransactionsNumber(blockDetails.height, blockDetails.alreadyGeneratedTransactions)) {
     return false;
   }

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -403,7 +403,7 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t start_time;
     uint8_t block_major_version;
     std::string already_generated_coins;
-    std::string contact;   
+    std::string contact;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)


### PR DESCRIPTION
responses because that large uint64_t number is unsafe in JavaScript environment and therefore as a JSON value and is not working properly:

```
"result": {
        "block": {
            "alreadyGeneratedCoins": "9988883.631436124907",
```
vs 
```
"result": {
        "block": {
            "alreadyGeneratedCoins": -8457860442273426709,
``` 
