### PR TITLE
Fix P2P gray peer housekeeping

### DIFF
--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -5,7 +5,7 @@
 // Copyright (c) 2018-2019, The TurtleCoin developers
 // Copyright (c) 2018-2022, Conceal Network & Conceal Devs
 // Copyright (c) 2020-2022, The Talleo developers
-// Copyright (c) 2016-2022, The Karbo developers
+// Copyright (c) 2016-2026, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <fstream>
 #include <thread>
+#include <cstdio>
 
 #include <boost/foreach.hpp>
 #include <boost/uuid/random_generator.hpp>
@@ -278,6 +279,7 @@ namespace CryptoNote
   //----------------------------------------------------------------------------------- 
   void NodeServer::for_each_connection(const std::function<void(CryptoNoteConnectionContext &, PeerIdType)> &f)
   {
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     for (auto& ctx : m_connections) {
       f(ctx.second, ctx.second.peerId);
     }
@@ -551,7 +553,14 @@ namespace CryptoNote
 
     m_stopEvent.wait();
 
-    logger(INFO) << "Stopping p2p NodeServer and its " << m_connections.size() << " connections...";
+    size_t connectionsCount = 0;
+    {
+      std::lock_guard<std::mutex> lock(m_connectionsMutex);
+      connectionsCount = m_connections.size();
+    }
+
+    logger(INFO) << "Stopping p2p NodeServer and its " << connectionsCount << " connections...";
+
     m_workingContextGroup.interrupt();
     m_workingContextGroup.wait();
 
@@ -562,6 +571,7 @@ namespace CryptoNote
   //-----------------------------------------------------------------------------------
   
   uint64_t NodeServer::get_connections_count() {
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     return m_connections.size();
   }
   //-----------------------------------------------------------------------------------
@@ -574,6 +584,7 @@ namespace CryptoNote
   
   bool NodeServer::store_config()
   {
+    std::lock_guard<std::mutex> storeLock(m_configStoreMutex);
     try {
       if (!Tools::create_directories_if_necessary(m_config_folder)) {
         logger(INFO) << "Failed to create data directory: " << m_config_folder;
@@ -581,16 +592,32 @@ namespace CryptoNote
       }
 
       std::string state_file_path = m_config_folder + "/" + m_p2p_state_filename;
+      std::string state_file_path_tmp = state_file_path + ".tmp";
       std::ofstream p2p_data;
-      p2p_data.open(state_file_path, std::ios_base::binary | std::ios_base::out | std::ios::trunc);
-      if (p2p_data.fail())  {
-        logger(INFO) << "Failed to save P2P state to file " << state_file_path;
+      p2p_data.open(state_file_path_tmp, std::ios_base::binary | std::ios_base::out | std::ios::trunc);
+      if (p2p_data.fail()) {
+        logger(INFO) << "Failed to save P2P state to file " << state_file_path_tmp;
         return false;
-      };
+      }
 
       StdOutputStream stream(p2p_data);
       BinaryOutputStreamSerializer a(stream);
       CryptoNote::serialize(*this, a);
+
+      if (p2p_data.fail()) {
+        logger(INFO) << "Failed to serialize P2P state to file " << state_file_path_tmp;
+        return false;
+      }
+
+      p2p_data.flush();
+      p2p_data.close();
+
+      std::remove(state_file_path.c_str());
+      if (std::rename(state_file_path_tmp.c_str(), state_file_path.c_str()) != 0) {
+        logger(INFO) << "Failed to move P2P state file from " << state_file_path_tmp << " to " << state_file_path;
+        return false;
+      }
+
       return true;
     } catch (const std::exception& e) {
       logger(TRACE) << "store_config failed: " << e.what();
@@ -598,6 +625,7 @@ namespace CryptoNote
 
     return false;
   }
+
   //-----------------------------------------------------------------------------------
   
   bool NodeServer::sendStopSignal()  {
@@ -613,6 +641,7 @@ namespace CryptoNote
   }
 
   //----------------------------------------------------------------------------------- 
+
   bool NodeServer::handshake(CryptoNote::LevinProtocol& proto, P2pConnectionContext& context, bool just_take_peerlist) {
     COMMAND_HANDSHAKE::request arg;
     COMMAND_HANDSHAKE::response rsp;
@@ -668,7 +697,8 @@ namespace CryptoNote
     return true;
   }
 
-  
+  //----------------------------------------------------------------------------------- 
+
   bool NodeServer::timedSync() {
     COMMAND_TIMED_SYNC::request arg = boost::value_initialized<COMMAND_TIMED_SYNC::request>();
     m_payload_handler.get_payload_sync_data(arg.payload_data);
@@ -684,6 +714,8 @@ namespace CryptoNote
 
     return true;
   }
+
+  //----------------------------------------------------------------------------------- 
 
   bool NodeServer::handleTimedSyncResponse(const BinaryArray& in, P2pConnectionContext& context) {
     COMMAND_TIMED_SYNC::response rsp;
@@ -707,28 +739,22 @@ namespace CryptoNote
     return true;
   }
 
+  //----------------------------------------------------------------------------------- 
+
   void NodeServer::forEachConnection(const std::function<void(P2pConnectionContext&)> action) {
-
-    // create copy of connection ids because the list can be changed during action
-    std::vector<boost::uuids::uuid> connectionIds;
-    connectionIds.reserve(m_connections.size());
-    for (const auto& c : m_connections) {
-      connectionIds.push_back(c.first);
-    }
-
-    for (const auto& connId : connectionIds) {
-      auto it = m_connections.find(connId);
-      if (it != m_connections.end()) {
-        action(it->second);
-      }
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
+    for (auto& c : m_connections) {
+      action(c.second);
     }
   }
 
   //----------------------------------------------------------------------------------- 
+
   bool NodeServer::is_peer_used(const PeerlistEntry& peer) const {
     if(m_config.m_peer_id == peer.id)
       return true; //dont make connections to ourself
 
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     for (const auto& kv : m_connections) {
       const auto& cntxt = kv.second;
       if(cntxt.peerId == peer.id || (!cntxt.m_is_income && peer.adr.ip == cntxt.m_remote_ip && peer.adr.port == cntxt.m_remote_port)) {
@@ -739,10 +765,12 @@ namespace CryptoNote
   }
 
   //----------------------------------------------------------------------------------- 
+
   bool NodeServer::is_peer_used(const AnchorPeerlistEntry& peer) const {
     if(m_config.m_peer_id == peer.id)
       return true; //dont make connections to ourself
 
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     for (const auto& kv : m_connections) {
       const auto& cntxt = kv.second;
       if(cntxt.peerId == peer.id || (!cntxt.m_is_income && peer.adr.ip == cntxt.m_remote_ip && peer.adr.port == cntxt.m_remote_port)) {
@@ -751,9 +779,11 @@ namespace CryptoNote
     }
     return false;
   }
+
   //-----------------------------------------------------------------------------------
   
   bool NodeServer::is_addr_connected(const NetworkAddress& peer) const {
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     for (const auto& conn : m_connections) {
       if (!conn.second.m_is_income && peer.ip == conn.second.m_remote_ip && peer.port == conn.second.m_remote_port) {
         return true;
@@ -762,6 +792,7 @@ namespace CryptoNote
     return false;
   }
 
+  //-----------------------------------------------------------------------------------
 
   bool NodeServer::try_to_connect_and_handshake_with_new_peer(const NetworkAddress& na, bool just_take_peerlist, uint64_t last_seen_stamp, PeerType peer_type, uint64_t first_seen_stamp)  {
 
@@ -841,11 +872,25 @@ namespace CryptoNote
         throw System::InterruptedException();
       }
 
-      auto iter = m_connections.emplace(ctx.m_connection_id, std::move(ctx)).first;
-      const boost::uuids::uuid& connectionId = iter->first;
-      P2pConnectionContext& connectionContext = iter->second;
+      const boost::uuids::uuid connectionId = ctx.m_connection_id;
+      {
+        std::lock_guard<std::mutex> lock(m_connectionsMutex);
+        m_connections.emplace(connectionId, std::move(ctx));
+      }
 
-      m_workingContextGroup.spawn(std::bind(&NodeServer::connectionHandler, this, std::cref(connectionId), std::ref(connectionContext)));
+      m_workingContextGroup.spawn([this, connectionId] {
+        P2pConnectionContext* connection = nullptr;
+        {
+          std::lock_guard<std::mutex> lock(m_connectionsMutex);
+          auto it = m_connections.find(connectionId);
+          if (it == m_connections.end()) {
+            return;
+          }
+          connection = &it->second;
+        }
+
+        connectionHandler(connectionId, *connection);
+      });
 
       return true;
     } catch (const System::InterruptedException&) {
@@ -859,6 +904,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   bool NodeServer::make_new_connection_from_peerlist(bool use_white_list)
   {
     size_t local_peers_count = use_white_list ? m_peerlist.get_white_peers_count() : m_peerlist.get_gray_peers_count();
@@ -1052,8 +1098,10 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   size_t NodeServer::get_outgoing_connections_count() const {
     size_t count = 0;
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     for (const auto& cntxt : m_connections) {
       if (!cntxt.second.m_is_income)
         ++count;
@@ -1062,6 +1110,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   bool NodeServer::fix_time_delta(std::vector<PeerlistEntry>& local_peerlist, time_t local_time, int64_t& delta) const
   {
     //fix time delta
@@ -1082,6 +1131,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   bool NodeServer::handle_remote_peerlist(const std::vector<PeerlistEntry>& peerlist, time_t local_time, const CryptoNoteConnectionContext& context)
   {
     if (peerlist.size() > P2P_MAX_PEERS_IN_HANDSHAKE)
@@ -1100,6 +1150,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   bool NodeServer::get_local_node_data(basic_node_data& node_data) const
   {
     node_data.version = CryptoNote::P2P_CURRENT_VERSION;
@@ -1116,6 +1167,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   void NodeServer::relay_notify_to_all(int command, const BinaryArray& data_buff, const net_connection_id* excludeConnection) {
     net_connection_id excludeId = excludeConnection ? *excludeConnection : boost::value_initialized<net_connection_id>();
 
@@ -1129,7 +1181,9 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   bool NodeServer::invoke_notify_to_peer(int command, const BinaryArray& buffer, const CryptoNoteConnectionContext& context) {
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     auto it = m_connections.find(context.m_connection_id);
     if (it == m_connections.end()) {
       return false;
@@ -1141,6 +1195,7 @@ namespace CryptoNote
   }
 
   //-----------------------------------------------------------------------------------
+
   bool NodeServer::try_ping(const basic_node_data& node_data, const P2pConnectionContext& context) {
     if(!node_data.my_port) {
       return false;
@@ -1186,6 +1241,7 @@ namespace CryptoNote
   }
 
   //----------------------------------------------------------------------------------- 
+
   int NodeServer::handle_timed_sync(int command, const COMMAND_TIMED_SYNC::request& arg, COMMAND_TIMED_SYNC::response& rsp, P2pConnectionContext& context)
   {
     if(!m_payload_handler.process_payload_sync_data(arg.payload_data, context, false)) {
@@ -1212,6 +1268,7 @@ namespace CryptoNote
     logger(Logging::TRACE) << context << "COMMAND_TIMED_SYNC";
     return 1;
   }
+
   //-----------------------------------------------------------------------------------
   
   int NodeServer::handle_handshake(int command, const COMMAND_HANDSHAKE::request& arg, COMMAND_HANDSHAKE::response& rsp, P2pConnectionContext& context)
@@ -1279,6 +1336,7 @@ namespace CryptoNote
     logger(Logging::DEBUGGING, Logging::BRIGHT_GREEN) << "COMMAND_HANDSHAKE";
     return 1;
   }
+
   //-----------------------------------------------------------------------------------
   
   int NodeServer::handle_ping(int command, const COMMAND_PING::request& arg, COMMAND_PING::response& rsp, const P2pConnectionContext& context) const
@@ -1288,6 +1346,7 @@ namespace CryptoNote
     rsp.peer_id = m_config.m_peer_id;
     return 1;
   }
+
   //-----------------------------------------------------------------------------------
   
   bool NodeServer::log_peerlist() const
@@ -1301,6 +1360,7 @@ namespace CryptoNote
                          << "Peerlist gray:" << ENDL << print_peerlist_to_string(pl_gray) ;
     return true;
   }
+
   //-----------------------------------------------------------------------------------
   
   bool NodeServer::log_banlist() const
@@ -1312,18 +1372,21 @@ namespace CryptoNote
 
     return true;
   }
+
   //-----------------------------------------------------------------------------------
 
   bool NodeServer::log_connections() const {
     logger(INFO) << "Connections: \r\n" << print_connections_container() ;
     return true;
   }
+
   //-----------------------------------------------------------------------------------
   
   std::string NodeServer::print_connections_container() const {
 
     std::stringstream ss;
 
+    std::lock_guard<std::mutex> lock(m_connectionsMutex);
     for (const auto& cntxt : m_connections) {
       ss << Common::ipAddressToString(cntxt.second.m_remote_ip) << ":" << cntxt.second.m_remote_port
         << " \t\tpeer_id " << cntxt.second.peerId
@@ -1333,6 +1396,7 @@ namespace CryptoNote
 
     return ss.str();
   }
+
   //-----------------------------------------------------------------------------------
   
   void NodeServer::on_connection_new(P2pConnectionContext& context)
@@ -1340,6 +1404,7 @@ namespace CryptoNote
     logger(TRACE) << context << "NEW CONNECTION";
     m_payload_handler.onConnectionOpened(context);
   }
+
   //-----------------------------------------------------------------------------------
   
   void NodeServer::on_connection_close(P2pConnectionContext& context)
@@ -1355,6 +1420,8 @@ namespace CryptoNote
     logger(TRACE) << context << "CLOSE CONNECTION";
     m_payload_handler.onConnectionClosed(context);
   }
+
+  //-----------------------------------------------------------------------------------
   
   bool NodeServer::is_priority_node(const NetworkAddress& na) const
   {
@@ -1373,6 +1440,8 @@ namespace CryptoNote
 
     return true;
   }
+
+  //-----------------------------------------------------------------------------------
 
   bool NodeServer::gray_peerlist_housekeeping() {
     PeerlistEntry pe = boost::value_initialized<PeerlistEntry>();
@@ -1401,6 +1470,8 @@ namespace CryptoNote
     return true;
   }
 
+  //-----------------------------------------------------------------------------------
+
   bool NodeServer::parse_peers_and_add_to_container(const boost::program_options::variables_map& vm, 
     const command_line::arg_descriptor<std::vector<std::string> > & arg, std::vector<NetworkAddress>& container) const
   {
@@ -1418,6 +1489,8 @@ namespace CryptoNote
     return true;
   }
 
+  //-----------------------------------------------------------------------------------
+
   void NodeServer::acceptLoop() {
     while(!m_stop) {
       try {
@@ -1430,11 +1503,26 @@ namespace CryptoNote
         ctx.m_remote_ip = hostToNetwork(addressAndPort.first.getValue());
         ctx.m_remote_port = addressAndPort.second;
 
-        auto iter = m_connections.emplace(ctx.m_connection_id, std::move(ctx)).first;
-        const boost::uuids::uuid& connectionId = iter->first;
-        P2pConnectionContext& connection = iter->second;
+        const boost::uuids::uuid connectionId = ctx.m_connection_id;
+        {
+          std::lock_guard<std::mutex> lock(m_connectionsMutex);
+          m_connections.emplace(connectionId, std::move(ctx));
+        }
 
-        m_workingContextGroup.spawn(std::bind(&NodeServer::connectionHandler, this, std::cref(connectionId), std::ref(connection)));
+        m_workingContextGroup.spawn([this, connectionId] {
+          P2pConnectionContext* connection = nullptr;
+          {
+            std::lock_guard<std::mutex> lock(m_connectionsMutex);
+            auto it = m_connections.find(connectionId);
+            if (it == m_connections.end()) {
+              return;
+            }
+            connection = &it->second;
+          }
+
+        connectionHandler(connectionId, *connection);
+      });
+
       } catch (const System::InterruptedException&) {
         logger(DEBUGGING) << "acceptLoop() is interrupted";
         break;
@@ -1445,6 +1533,8 @@ namespace CryptoNote
 
     logger(DEBUGGING) << "acceptLoop finished";
   }
+
+  //-----------------------------------------------------------------------------------
 
   void NodeServer::onIdle() {
     logger(DEBUGGING) << "onIdle started";
@@ -1465,6 +1555,8 @@ namespace CryptoNote
     logger(DEBUGGING) << "onIdle finished";
   }
 
+  //-----------------------------------------------------------------------------------
+
   void NodeServer::connectionWorker() {
     logger(DEBUGGING) << "connectionWorker started";
 
@@ -1482,12 +1574,15 @@ namespace CryptoNote
     logger(DEBUGGING) << "connectionWorker finished";
   }
 
+  //-----------------------------------------------------------------------------------
+
   void NodeServer::timeoutLoop() {
     try {
       while (!m_stop) {
         m_timeoutTimer.sleep(std::chrono::seconds(10));
         auto now = P2pConnectionContext::Clock::now();
 
+        std::lock_guard<std::mutex> lock(m_connectionsMutex);
         for (auto& kv : m_connections) {
           auto& ctx = kv.second;
           if (ctx.writeDuration(now) > P2P_DEFAULT_INVOKE_TIMEOUT) {
@@ -1503,6 +1598,8 @@ namespace CryptoNote
     }
   }
 
+  //-----------------------------------------------------------------------------------
+
   void NodeServer::timedSyncLoop() {
     try {
       for (;;) {
@@ -1517,6 +1614,8 @@ namespace CryptoNote
 
     logger(DEBUGGING) << "timedSyncLoop finished";
   }
+
+  //-----------------------------------------------------------------------------------
 
   void NodeServer::connectionHandler(const boost::uuids::uuid& connectionId, P2pConnectionContext& ctx) {
     // This inner context is necessary in order to stop connection handler at any moment
@@ -1571,7 +1670,10 @@ namespace CryptoNote
       writeContext.get();
 
       on_connection_close(ctx);
-      m_connections.erase(connectionId);
+      {
+        std::lock_guard<std::mutex> lock(m_connectionsMutex);
+        m_connections.erase(connectionId);
+      }
     });
 
     ctx.context = &context;
@@ -1582,6 +1684,8 @@ namespace CryptoNote
       logger(DEBUGGING) << "connectionHandler() is interrupted";
     }
   }
+
+  //-----------------------------------------------------------------------------------
 
   void NodeServer::writeHandler(P2pConnectionContext& ctx) const {
     logger(DEBUGGING) << ctx << "writeHandler started";

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1455,15 +1455,13 @@ namespace CryptoNote
     if (!m_peerlist.get_gray_peer_by_index(pe, random_index))
       return false;
 
-    if (!try_to_connect_and_handshake_with_new_peer(pe.adr, false, 0, gray, pe.last_seen)) {
+    if (!try_to_connect_and_handshake_with_new_peer(pe.adr, false, pe.last_seen, gray, 0)) {
       time_t now = time(nullptr);
       if (now - pe.last_seen >= LAST_SEEN_EVICT_THRESHOLD) {
         m_peerlist.remove_from_peer_gray(pe);
         logger(DEBUGGING) << "PEER EVICTED FROM GRAY PEER LIST IP address: " << Common::ipAddressToString(pe.adr.ip) << " Peer ID: " << std::hex << pe.id;
       }
     } else {
-      pe.last_seen = time(nullptr);
-      m_peerlist.append_with_peer_white(pe);
       logger(DEBUGGING) << "PEER PROMOTED TO WHITE PEER LIST IP address: " << Common::ipAddressToString(pe.adr.ip) << " Peer ID: " << std::hex << pe.id;
     }
 

--- a/src/P2p/NetNode.h
+++ b/src/P2p/NetNode.h
@@ -225,5 +225,7 @@ namespace CryptoNote
     std::map<uint32_t, uint64_t> m_host_fails_score;
 
     mutable std::mutex mutex;
+    mutable std::mutex m_connectionsMutex;
+    mutable std::mutex m_configStoreMutex;
   };
 }

--- a/src/P2p/PeerListManager.cpp
+++ b/src/P2p/PeerListManager.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2017, The Monero project
-// Copyright (c) 2016-2025, The Karbo developers
+// Copyright (c) 2016-2026, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -124,6 +124,18 @@ void PeerlistManager::trim_white_peerlist() {
 void PeerlistManager::trim_gray_peerlist() {
   std::lock_guard<std::recursive_mutex> lock(mutex_);
   m_grayPeerlist.trim();
+}
+
+//--------------------------------------------------------------------------------------------------
+size_t PeerlistManager::get_white_peers_count() const {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  return m_peers_white.size();
+}
+
+//--------------------------------------------------------------------------------------------------
+size_t PeerlistManager::get_gray_peers_count() const {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  return m_peers_gray.size();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -319,8 +331,11 @@ bool PeerlistManager::append_with_peer_gray(const PeerlistEntry& ple)
     }
     else
     {
-      //update record in white list 
-      m_peers_gray.replace(by_addr_it_gr, ple);
+      // update only if the incoming timestamp is newer,
+      // otherwise old remote entries can age gray peers backwards.
+      if (ple.last_seen > by_addr_it_gr->last_seen) {
+        m_peers_gray.replace(by_addr_it_gr, ple);
+      }
     }
     return true;
   }

--- a/src/P2p/PeerListManager.h
+++ b/src/P2p/PeerListManager.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2012-2016, The CryptoNote developers, The Bytecoin developers
 // Copyright (c) 2014-2017, The Monero project
-// Copyright (c) 2016-2025, The Karbo developers
+// Copyright (c) 2016-2026, The Karbo developers
 //
 // This file is part of Karbo.
 //
@@ -79,8 +79,8 @@ public:
   PeerlistManager();
 
   bool init(bool allow_local_ip);
-  size_t get_white_peers_count() const { return m_peers_white.size(); }
-  size_t get_gray_peers_count() const { return m_peers_gray.size(); }
+  size_t get_white_peers_count() const;
+  size_t get_gray_peers_count() const;
   bool merge_peerlist(const std::vector<PeerlistEntry>& outer_bs);
   bool get_peerlist_head(std::vector<PeerlistEntry>& bs_head, uint32_t depth = CryptoNote::P2P_DEFAULT_PEERS_IN_HANDSHAKE) const;
   bool get_peerlist_full(std::list<AnchorPeerlistEntry>& pl_anchor, std::vector<PeerlistEntry>& pl_gray, std::vector<PeerlistEntry>& pl_white) const;


### PR DESCRIPTION
* Fixed gray peer housekeeping so successful housekeeping handshakes no longer re-write whitelist entries from stale gray metadata.
* Corrected argument ordering so gray last_seen is passed as last_seen_stamp (instead of incorrectly being used as anchor first_seen).
* Improved P2P state-file replacement flow by keeping atomic rename semantics (removed pre-delete of the destination file before rename).
* Made PeerlistManager white/gray count accessors synchronized.
* Fixed gray peer merge behavior to avoid regressing last_seen when an older remote peerlist entry arrives; gray entry replacement now happens only for newer timestamps, which directly stabilizes housekeeping eviction logic.