### PR TITLE
RE-fix typo in log message for UPnP device recognition

### DIFF
--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -98,7 +98,7 @@ void addPortMapping(const Logging::LoggerRef& logger, uint32_t port, uint32_t ex
     } else if (result == 2) {
       logger(INFO) << "IGD was found but reported as not connected.";
     } else if (result == 3) {
-      logger(INFO) << "UPnP device was found but not recoginzed as IGD.";
+      logger(INFO) << "UPnP device was found but not recognized as IGD.";
     } else {
       logger(ERROR) << "UPNP_GetValidIGD returned an unknown result code.";
     }


### PR DESCRIPTION
hadnt even `recognized` my typo fix had typo ;) :man_facepalming: 