### PR TITLE
Human-readable account numbers

### DIFF
--- a/include/INode.h
+++ b/include/INode.h
@@ -179,6 +179,14 @@ public:
   virtual void getBlockTimestamp(uint32_t height, uint64_t& timestamp, const Callback& callback) = 0;
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) = 0;
   virtual void getConnections(std::vector<p2pConnection>& connections, const Callback& callback) = 0;
+
+  // Account number resolution (default implementations return error)
+  virtual void resolveAccountNumber(const std::string& accountNumber, std::string& address, const Callback& callback) {
+    callback(std::make_error_code(std::errc::not_supported));
+  }
+  virtual void getAccountNumber(const std::string& address, std::string& accountNumber, const Callback& callback) {
+    callback(std::make_error_code(std::errc::not_supported));
+  }
 };
 
 }

--- a/src/CryptoNoteCore/AccountNumber.h
+++ b/src/CryptoNoteCore/AccountNumber.h
@@ -1,0 +1,119 @@
+// Copyright (c) 2016-2026, The Karbo developers
+//
+// This file is part of Karbo.
+//
+// Karbo is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Karbo is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with Karbo.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace CryptoNote {
+
+struct AccountNumber {
+  uint32_t blockHeight;
+  uint32_t txIndex;
+
+  uint64_t toUint64() const {
+    return (static_cast<uint64_t>(blockHeight) << 32) | static_cast<uint64_t>(txIndex);
+  }
+
+  static AccountNumber fromUint64(uint64_t packed) {
+    return { static_cast<uint32_t>(packed >> 32), static_cast<uint32_t>(packed & 0xFFFFFFFF) };
+  }
+
+  std::string toString() const {
+    std::string digits = std::to_string(blockHeight) + std::to_string(txIndex);
+    char check = luhnMod36Generate(digits);
+    return std::to_string(blockHeight) + "-" + std::to_string(txIndex) + "-" + check;
+  }
+
+  static bool fromString(const std::string& str, AccountNumber& out) {
+    // Format: H-I-C
+    size_t dash1 = str.find('-');
+    if (dash1 == std::string::npos) return false;
+
+    size_t dash2 = str.find('-', dash1 + 1);
+    if (dash2 == std::string::npos) return false;
+
+    std::string hStr = str.substr(0, dash1);
+    std::string iStr = str.substr(dash1 + 1, dash2 - dash1 - 1);
+    std::string cStr = str.substr(dash2 + 1);
+
+    if (hStr.empty() || iStr.empty() || cStr.size() != 1) return false;
+
+    // Validate H and I are numeric
+    for (char c : hStr) { if (c < '0' || c > '9') return false; }
+    for (char c : iStr) { if (c < '0' || c > '9') return false; }
+
+    uint64_t h, i;
+    try {
+      h = std::stoull(hStr);
+      i = std::stoull(iStr);
+    } catch (...) {
+      return false;
+    }
+
+    if (h > UINT32_MAX || i > UINT32_MAX) return false;
+
+    // Validate check character
+    std::string digits = hStr + iStr;
+    char expectedCheck = luhnMod36Generate(digits);
+    char actualCheck = static_cast<char>(std::toupper(static_cast<unsigned char>(cStr[0])));
+    if (actualCheck != expectedCheck) return false;
+
+    out.blockHeight = static_cast<uint32_t>(h);
+    out.txIndex = static_cast<uint32_t>(i);
+    return true;
+  }
+
+private:
+  static const char* alphabet() {
+    return "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  }
+
+  static int charToCode(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'A' && c <= 'Z') return c - 'A' + 10;
+    if (c >= 'a' && c <= 'z') return c - 'a' + 10;
+    return -1;
+  }
+
+  // Luhn mod 36: compute check character for input string of digits
+  static char luhnMod36Generate(const std::string& input) {
+    const int n = 36;
+    int sum = 0;
+    // Process from right to left; first char from right gets factor 2
+    bool doubleFlag = true;
+    for (int idx = static_cast<int>(input.size()) - 1; idx >= 0; --idx) {
+      int codePoint = charToCode(input[idx]);
+      if (codePoint < 0) return '?';
+
+      if (doubleFlag) {
+        codePoint *= 2;
+        if (codePoint >= n) {
+          codePoint = (codePoint / n) + (codePoint % n);
+        }
+      }
+      sum += codePoint;
+      doubleFlag = !doubleFlag;
+    }
+    int remainder = sum % n;
+    int checkCodePoint = (n - remainder) % n;
+    return alphabet()[checkCodePoint];
+  }
+};
+
+} // namespace CryptoNote

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2573,6 +2573,15 @@ bool Blockchain::pushTransaction(BlockEntry& block, const Crypto::Hash& transact
     }
   }
 
+  // Record account registration
+  {
+    TransactionExtraAccountRegistration reg;
+    if (getAccountRegistrationFromExtra(tx.extra, reg)) {
+      m_db.putAccountRegistration(block.height, transactionIndex.transaction,
+                                  reg.spendPublicKey.data, reg.viewPublicKey.data);
+    }
+  }
+
   // Serialize and store tx entry: [u32 tx_size][tx_blob][u32 num_gidx][u32 gidx...]
   BinaryArray txBlob = toBinaryArray(tx);
   uint32_t txSize  = static_cast<uint32_t>(txBlob.size());
@@ -2621,6 +2630,17 @@ void Blockchain::popTransaction(const Transaction& transaction,
     Crypto::Hash paymentId;
     if (getPaymentIdFromTxExtra(transaction.extra, paymentId)) {
       m_db.removePaymentId(paymentId, transactionHash);
+    }
+  }
+
+  // Remove account registration
+  {
+    TransactionExtraAccountRegistration reg;
+    if (getAccountRegistrationFromExtra(transaction.extra, reg)) {
+      uint32_t block; uint16_t txSlot;
+      if (m_db.getTxIndex(transactionHash, block, txSlot)) {
+        m_db.removeAccountRegistration(block, txSlot);
+      }
     }
   }
 
@@ -2858,6 +2878,42 @@ bool Blockchain::isBlockInMainChain(const Crypto::Hash& blockId) {
 
 bool Blockchain::isInCheckpointZone(const uint32_t height) {
   return m_checkpoints.is_in_checkpoint_zone(height);
+}
+
+// ─── Account number lookups ──────────────────────────────────────────────────
+
+bool Blockchain::resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
+                                      AccountPublicAddress& address) {
+  std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
+  uint8_t spendKey[32], viewKey[32];
+  if (!m_db.getAccountRegistration(blockHeight, txIndex, spendKey, viewKey)) {
+    return false;
+  }
+  memcpy(address.spendPublicKey.data, spendKey, 32);
+  memcpy(address.viewPublicKey.data, viewKey, 32);
+  return true;
+}
+
+bool Blockchain::getAccountNumber(const AccountPublicAddress& address,
+                                  uint32_t& blockHeight, uint32_t& txIndex) {
+  std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
+  std::vector<std::pair<uint32_t, uint32_t>> results;
+  if (!m_db.findAccountRegistrationsByKeys(address.spendPublicKey.data,
+                                            address.viewPublicKey.data,
+                                            true, results)) {
+    return false;
+  }
+  blockHeight = results[0].first;
+  txIndex = results[0].second;
+  return true;
+}
+
+bool Blockchain::getAllAccountNumbers(const AccountPublicAddress& address,
+                                     std::vector<std::pair<uint32_t, uint32_t>>& results) {
+  std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
+  return m_db.findAccountRegistrationsByKeys(address.spendPublicKey.data,
+                                              address.viewPublicKey.data,
+                                              false, results);
 }
 
 // ─── blockDifficulty / blockCumulativeDifficulty / getblockEntry ─────────────

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2582,10 +2582,11 @@ bool Blockchain::pushTransaction(BlockEntry& block, const Crypto::Hash& transact
     }
   }
 
-  // Record account registration
-  {
+  // Record account registration (non-coinbase only, well-formed only)
+  if (transactionIndex.transaction != 0) {
     TransactionExtraAccountRegistration reg;
-    if (getAccountRegistrationFromExtra(tx.extra, reg)) {
+    if (getAccountRegistrationFromExtra(tx.extra, reg) &&
+        isWellFormedAccountRegistration(tx.extra)) {
       m_db.putAccountRegistration(block.height, transactionIndex.transaction,
                                   reg.spendPublicKey.data, reg.viewPublicKey.data);
     }

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2907,23 +2907,9 @@ bool Blockchain::resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
 bool Blockchain::getAccountNumber(const AccountPublicAddress& address,
                                   uint32_t& blockHeight, uint32_t& txIndex) {
   std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
-  std::vector<std::pair<uint32_t, uint32_t>> results;
-  if (!m_db.findAccountRegistrationsByKeys(address.spendPublicKey.data,
+  return m_db.findAccountRegistrationByKeys(address.spendPublicKey.data,
                                             address.viewPublicKey.data,
-                                            true, results)) {
-    return false;
-  }
-  blockHeight = results[0].first;
-  txIndex = results[0].second;
-  return true;
-}
-
-bool Blockchain::getAllAccountNumbers(const AccountPublicAddress& address,
-                                     std::vector<std::pair<uint32_t, uint32_t>>& results) {
-  std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
-  return m_db.findAccountRegistrationsByKeys(address.spendPublicKey.data,
-                                              address.viewPublicKey.data,
-                                              false, results);
+                                            blockHeight, txIndex);
 }
 
 // ─── blockDifficulty / blockCumulativeDifficulty / getblockEntry ─────────────

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -19,6 +19,7 @@
 #include "Blockchain.h"
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
 #include <cstdio>
 #include <cmath>
@@ -2956,6 +2957,11 @@ bool Blockchain::isInCheckpointZone(const uint32_t height) {
 bool Blockchain::resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
                                       AccountPublicAddress& address) {
   std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
+  const uint32_t chainHeight = m_db.getChainHeight();
+  if (blockHeight >= chainHeight || txIndex == 0 ||
+      txIndex > std::numeric_limits<uint16_t>::max()) {
+    return false;
+  }
   uint8_t spendKey[32], viewKey[32];
   if (m_db.getAccountRegistration(blockHeight, txIndex, spendKey, viewKey)) {
     memcpy(address.spendPublicKey.data, spendKey, 32);
@@ -2964,9 +2970,6 @@ bool Blockchain::resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
   }
 
   // Fallback: registration may predate the index — fetch the tx directly
-  if (blockHeight >= m_db.getChainHeight() || txIndex == 0) {
-    return false;
-  }
   try {
     TransactionEntry te = transactionByIndex({ blockHeight, static_cast<uint16_t>(txIndex) });
     TransactionExtraAccountRegistration reg;

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -482,6 +482,67 @@ bool Blockchain::init(const std::string& config_folder, bool load_existing) {
 
   update_next_cumulative_size_limit();
 
+  // One-time backfill of account registration index for blocks that predate it.
+  // Scans backwards from chain tip down to the first known registration.
+  // If the first registration (1264265, 1) is already indexed, skip entirely.
+  {
+    static const uint32_t ACCT_REG_FIRST_HEIGHT = 1264265;
+    static const uint16_t ACCT_REG_FIRST_TX     = 1;
+    chainHeight = m_db.getChainHeight();
+
+    if (chainHeight > ACCT_REG_FIRST_HEIGHT) {
+      uint8_t sk[32], vk[32];
+      if (!m_db.getAccountRegistration(ACCT_REG_FIRST_HEIGHT, ACCT_REG_FIRST_TX, sk, vk)) {
+        logger(INFO, BRIGHT_WHITE) << "Backfilling account registration index from block "
+          << (chainHeight - 1) << " down to " << ACCT_REG_FIRST_HEIGHT << " ...";
+
+        uint32_t indexed = 0;
+        static const uint32_t BATCH = 1000;
+        uint32_t batchCount = 0;
+
+        for (uint32_t h = chainHeight - 1; h >= ACCT_REG_FIRST_HEIGHT; --h) {
+          if (batchCount == 0) {
+            m_db.growMapIfNeeded();
+            m_db.beginWriteTxn();
+          }
+
+          DbBlockMeta meta{};
+          m_db.getBlockMeta(h, meta);
+
+          for (uint16_t t = 1; t < meta.txCount; ++t) {
+            uint8_t s[32], v[32];
+            if (m_db.getAccountRegistration(h, t, s, v)) {
+              continue;
+            }
+
+            try {
+              TransactionEntry te = transactionByIndex({ h, t });
+              TransactionExtraAccountRegistration reg;
+              if (getAccountRegistrationFromExtra(te.tx.extra, reg) &&
+                  isWellFormedAccountRegistration(te.tx.extra)) {
+                m_db.putAccountRegistration(h, t, reg.spendPublicKey.data, reg.viewPublicKey.data);
+                ++indexed;
+              }
+            } catch (...) {
+            }
+          }
+
+          ++batchCount;
+          if (batchCount >= BATCH || h == ACCT_REG_FIRST_HEIGHT) {
+            m_db.commitTxn();
+            batchCount = 0;
+          }
+        }
+
+        if (indexed > 0) {
+          logger(INFO, BRIGHT_GREEN) << "Account registration backfill complete: " << indexed << " registrations indexed.";
+        } else {
+          logger(INFO) << "Account registration backfill complete: no new registrations found.";
+        }
+      }
+    }
+  }
+
   chainHeight = m_db.getChainHeight();
   DbBlockMeta tailMeta{};
   m_db.getBlockMeta(chainHeight - 1, tailMeta);

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2896,12 +2896,28 @@ bool Blockchain::resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
                                       AccountPublicAddress& address) {
   std::lock_guard<std::recursive_mutex> lk(m_blockchain_lock);
   uint8_t spendKey[32], viewKey[32];
-  if (!m_db.getAccountRegistration(blockHeight, txIndex, spendKey, viewKey)) {
+  if (m_db.getAccountRegistration(blockHeight, txIndex, spendKey, viewKey)) {
+    memcpy(address.spendPublicKey.data, spendKey, 32);
+    memcpy(address.viewPublicKey.data, viewKey, 32);
+    return true;
+  }
+
+  // Fallback: registration may predate the index — fetch the tx directly
+  if (blockHeight >= m_db.getChainHeight() || txIndex == 0) {
     return false;
   }
-  memcpy(address.spendPublicKey.data, spendKey, 32);
-  memcpy(address.viewPublicKey.data, viewKey, 32);
-  return true;
+  try {
+    TransactionEntry te = transactionByIndex({ blockHeight, static_cast<uint16_t>(txIndex) });
+    TransactionExtraAccountRegistration reg;
+    if (getAccountRegistrationFromExtra(te.tx.extra, reg) &&
+        isWellFormedAccountRegistration(te.tx.extra)) {
+      address.spendPublicKey = reg.spendPublicKey;
+      address.viewPublicKey = reg.viewPublicKey;
+      return true;
+    }
+  } catch (...) {
+  }
+  return false;
 }
 
 bool Blockchain::getAccountNumber(const AccountPublicAddress& address,

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -145,6 +145,14 @@ namespace CryptoNote {
 
     bool getHashingBlob(const uint32_t height, BinaryArray& blob);
 
+    // Account number lookups
+    bool resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
+                              AccountPublicAddress& address);
+    bool getAccountNumber(const AccountPublicAddress& address,
+                          uint32_t& blockHeight, uint32_t& txIndex);
+    bool getAllAccountNumbers(const AccountPublicAddress& address,
+                             std::vector<std::pair<uint32_t, uint32_t>>& results);
+
     template<class visitor_t>
     bool scanOutputKeysForIndexes(const KeyInput& tx_in_to_key, visitor_t& vis,
                                    uint32_t* pmax_related_block_height = nullptr);

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -150,8 +150,6 @@ namespace CryptoNote {
                               AccountPublicAddress& address);
     bool getAccountNumber(const AccountPublicAddress& address,
                           uint32_t& blockHeight, uint32_t& txIndex);
-    bool getAllAccountNumbers(const AccountPublicAddress& address,
-                             std::vector<std::pair<uint32_t, uint32_t>>& results);
 
     template<class visitor_t>
     bool scanOutputKeysForIndexes(const KeyInput& tx_in_to_key, visitor_t& vis,

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -441,45 +441,11 @@ bool Core::check_tx_semantic(const Transaction& tx, const Crypto::Hash& txHash, 
 
   // Validate account registration tx extra
   {
-    std::vector<TransactionExtraField> extraFields;
-    if (parseTransactionExtra(tx.extra, extraFields)) {
-      int regCount = 0;
-      bool hasNonce = false;
-      for (const auto& field : extraFields) {
-        if (field.type() == typeid(TransactionExtraAccountRegistration)) {
-          ++regCount;
-        }
-        if (field.type() == typeid(TransactionExtraNonce)) {
-          hasNonce = true;
-        }
-      }
-
-      if (regCount > 1) {
-        logger(ERROR) << "tx contains multiple account registration fields, rejected for tx id= " << Common::podToHex(txHash);
+    TransactionExtraAccountRegistration reg;
+    if (getAccountRegistrationFromExtra(tx.extra, reg)) {
+      if (!isWellFormedAccountRegistration(tx.extra)) {
+        logger(ERROR) << "malformed account registration, rejected for tx id= " << Common::podToHex(txHash);
         return false;
-      }
-
-      if (regCount == 1) {
-        // Registration tx must not contain a payment ID (nonce)
-        if (hasNonce) {
-          logger(ERROR) << "account registration tx must not contain payment ID, rejected for tx id= " << Common::podToHex(txHash);
-          return false;
-        }
-
-        // Validate the pubkeys are valid Ed25519 points
-        TransactionExtraAccountRegistration reg;
-        findTransactionExtraFieldByType(extraFields, reg);
-        if (!Crypto::check_key(reg.spendPublicKey) || !Crypto::check_key(reg.viewPublicKey)) {
-          logger(ERROR) << "account registration contains invalid public keys, rejected for tx id= " << Common::podToHex(txHash);
-          return false;
-        }
-
-        // Check pubkeys are not the identity point
-        static const Crypto::PublicKey identity = {};
-        if (reg.spendPublicKey == identity || reg.viewPublicKey == identity) {
-          logger(ERROR) << "account registration contains identity public key, rejected for tx id= " << Common::podToHex(txHash);
-          return false;
-        }
       }
     }
   }

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -439,6 +439,51 @@ bool Core::check_tx_semantic(const Transaction& tx, const Crypto::Hash& txHash, 
     return false;
   }
 
+  // Validate account registration tx extra
+  {
+    std::vector<TransactionExtraField> extraFields;
+    if (parseTransactionExtra(tx.extra, extraFields)) {
+      int regCount = 0;
+      bool hasNonce = false;
+      for (const auto& field : extraFields) {
+        if (field.type() == typeid(TransactionExtraAccountRegistration)) {
+          ++regCount;
+        }
+        if (field.type() == typeid(TransactionExtraNonce)) {
+          hasNonce = true;
+        }
+      }
+
+      if (regCount > 1) {
+        logger(ERROR) << "tx contains multiple account registration fields, rejected for tx id= " << Common::podToHex(txHash);
+        return false;
+      }
+
+      if (regCount == 1) {
+        // Registration tx must not contain a payment ID (nonce)
+        if (hasNonce) {
+          logger(ERROR) << "account registration tx must not contain payment ID, rejected for tx id= " << Common::podToHex(txHash);
+          return false;
+        }
+
+        // Validate the pubkeys are valid Ed25519 points
+        TransactionExtraAccountRegistration reg;
+        findTransactionExtraFieldByType(extraFields, reg);
+        if (!Crypto::check_key(reg.spendPublicKey) || !Crypto::check_key(reg.viewPublicKey)) {
+          logger(ERROR) << "account registration contains invalid public keys, rejected for tx id= " << Common::podToHex(txHash);
+          return false;
+        }
+
+        // Check pubkeys are not the identity point
+        static const Crypto::PublicKey identity = {};
+        if (reg.spendPublicKey == identity || reg.viewPublicKey == identity) {
+          logger(ERROR) << "account registration contains identity public key, rejected for tx id= " << Common::podToHex(txHash);
+          return false;
+        }
+      }
+    }
+  }
+
   return true;
 }
 
@@ -1327,6 +1372,21 @@ bool Core::getMixin(const Transaction& transaction, uint64_t& mixin) {
     }
   }
   return true;
+}
+
+bool Core::resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
+                                AccountPublicAddress& address) {
+  return m_blockchain.resolveAccountNumber(blockHeight, txIndex, address);
+}
+
+bool Core::getAccountNumber(const AccountPublicAddress& address,
+                            uint32_t& blockHeight, uint32_t& txIndex) {
+  return m_blockchain.getAccountNumber(address, blockHeight, txIndex);
+}
+
+bool Core::getAllAccountNumbers(const AccountPublicAddress& address,
+                                std::vector<std::pair<uint32_t, uint32_t>>& results) {
+  return m_blockchain.getAllAccountNumbers(address, results);
 }
 
 bool Core::is_key_image_spent(const Crypto::KeyImage& key_im) {

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1350,11 +1350,6 @@ bool Core::getAccountNumber(const AccountPublicAddress& address,
   return m_blockchain.getAccountNumber(address, blockHeight, txIndex);
 }
 
-bool Core::getAllAccountNumbers(const AccountPublicAddress& address,
-                                std::vector<std::pair<uint32_t, uint32_t>>& results) {
-  return m_blockchain.getAllAccountNumbers(address, results);
-}
-
 bool Core::is_key_image_spent(const Crypto::KeyImage& key_im) {
   return m_blockchain.have_tx_keyimg_as_spent(key_im);
 }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -183,8 +183,6 @@ namespace CryptoNote {
                                        AccountPublicAddress& address) override;
      virtual bool getAccountNumber(const AccountPublicAddress& address,
                                    uint32_t& blockHeight, uint32_t& txIndex) override;
-     virtual bool getAllAccountNumbers(const AccountPublicAddress& address,
-                                      std::vector<std::pair<uint32_t, uint32_t>>& results) override;
 
      bool is_key_image_spent(const Crypto::KeyImage& key_im);
      bool is_key_image_spent(const Crypto::KeyImage& key_im, uint32_t height);

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -179,6 +179,13 @@ namespace CryptoNote {
      uint8_t getBlockMajorVersionForHeight(uint32_t height) const;
      virtual bool getMixin(const Transaction& transaction, uint64_t& mixin) override;
 
+     virtual bool resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
+                                       AccountPublicAddress& address) override;
+     virtual bool getAccountNumber(const AccountPublicAddress& address,
+                                   uint32_t& blockHeight, uint32_t& txIndex) override;
+     virtual bool getAllAccountNumbers(const AccountPublicAddress& address,
+                                      std::vector<std::pair<uint32_t, uint32_t>>& results) override;
+
      bool is_key_image_spent(const Crypto::KeyImage& key_im);
      bool is_key_image_spent(const Crypto::KeyImage& key_im, uint32_t height);
      bool is_tx_spendtime_unlocked(uint64_t unlock_time);

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -143,6 +143,13 @@ public:
 
   virtual bool getMixin(const Transaction& transaction, uint64_t& mixin) = 0;
   virtual bool isInCheckpointZone(uint32_t height) const = 0;
+
+  virtual bool resolveAccountNumber(uint32_t blockHeight, uint32_t txIndex,
+                                    AccountPublicAddress& address) = 0;
+  virtual bool getAccountNumber(const AccountPublicAddress& address,
+                                uint32_t& blockHeight, uint32_t& txIndex) = 0;
+  virtual bool getAllAccountNumbers(const AccountPublicAddress& address,
+                                   std::vector<std::pair<uint32_t, uint32_t>>& results) = 0;
 };
 
 } //namespace CryptoNote

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -148,8 +148,6 @@ public:
                                     AccountPublicAddress& address) = 0;
   virtual bool getAccountNumber(const AccountPublicAddress& address,
                                 uint32_t& blockHeight, uint32_t& txIndex) = 0;
-  virtual bool getAllAccountNumbers(const AccountPublicAddress& address,
-                                   std::vector<std::pair<uint32_t, uint32_t>>& results) = 0;
 };
 
 } //namespace CryptoNote

--- a/src/CryptoNoteCore/LMDBBlockchainDB.cpp
+++ b/src/CryptoNoteCore/LMDBBlockchainDB.cpp
@@ -935,7 +935,7 @@ bool LMDBBlockchainDB::findAccountRegistrationsByKeys(const uint8_t* spendKey, c
   checkRc(rc, "findAccountRegistrationsByKeys:open");
 
   MDB_val k{}, v{};
-  // Walk backwards from the end (newest first) for canonical lookup
+  // Walk backwards from the end — canonical account number is the most recent registration
   if (findFirst) {
     rc = mdb_cursor_get(cursor, &k, &v, MDB_LAST);
     while (rc == 0) {

--- a/src/CryptoNoteCore/LMDBBlockchainDB.cpp
+++ b/src/CryptoNoteCore/LMDBBlockchainDB.cpp
@@ -925,49 +925,30 @@ bool LMDBBlockchainDB::removeAccountRegistration(uint32_t blockHeight, uint32_t 
   return true;
 }
 
-bool LMDBBlockchainDB::findAccountRegistrationsByKeys(const uint8_t* spendKey, const uint8_t* viewKey,
-                                                      bool findFirst,
-                                                      std::vector<std::pair<uint32_t, uint32_t>>& results) const {
-  results.clear();
+bool LMDBBlockchainDB::findAccountRegistrationByKeys(const uint8_t* spendKey, const uint8_t* viewKey,
+                                                     uint32_t& blockHeight, uint32_t& txIndex) const {
   auto guard = readTxn();
   MDB_cursor* cursor = nullptr;
   int rc = mdb_cursor_open(guard.txn, m_dbiAccountRegistrations, &cursor);
-  checkRc(rc, "findAccountRegistrationsByKeys:open");
+  checkRc(rc, "findAccountRegistrationByKeys:open");
 
   MDB_val k{}, v{};
-  // Walk forward from the beginning — canonical account number is the first registration
-  if (findFirst) {
-    rc = mdb_cursor_get(cursor, &k, &v, MDB_FIRST);
-    while (rc == 0) {
-      if (v.mv_size == 64) {
-        const uint8_t* data = static_cast<const uint8_t*>(v.mv_data);
-        if (memcmp(data, spendKey, 32) == 0 && memcmp(data + 32, viewKey, 32) == 0) {
-          uint32_t h, i;
-          unpackAcctRegKey(static_cast<const uint8_t*>(k.mv_data), h, i);
-          results.push_back({h, i});
-          break;
-        }
+  // Walk forward — canonical account number is the first registration
+  rc = mdb_cursor_get(cursor, &k, &v, MDB_FIRST);
+  while (rc == 0) {
+    if (v.mv_size == 64) {
+      const uint8_t* data = static_cast<const uint8_t*>(v.mv_data);
+      if (memcmp(data, spendKey, 32) == 0 && memcmp(data + 32, viewKey, 32) == 0) {
+        unpackAcctRegKey(static_cast<const uint8_t*>(k.mv_data), blockHeight, txIndex);
+        mdb_cursor_close(cursor);
+        return true;
       }
-      rc = mdb_cursor_get(cursor, &k, &v, MDB_NEXT);
     }
-  } else {
-    // Full scan from beginning
-    rc = mdb_cursor_get(cursor, &k, &v, MDB_FIRST);
-    while (rc == 0) {
-      if (v.mv_size == 64) {
-        const uint8_t* data = static_cast<const uint8_t*>(v.mv_data);
-        if (memcmp(data, spendKey, 32) == 0 && memcmp(data + 32, viewKey, 32) == 0) {
-          uint32_t h, i;
-          unpackAcctRegKey(static_cast<const uint8_t*>(k.mv_data), h, i);
-          results.push_back({h, i});
-        }
-      }
-      rc = mdb_cursor_get(cursor, &k, &v, MDB_NEXT);
-    }
+    rc = mdb_cursor_get(cursor, &k, &v, MDB_NEXT);
   }
 
   mdb_cursor_close(cursor);
-  return !results.empty();
+  return false;
 }
 
 } // namespace CryptoNote

--- a/src/CryptoNoteCore/LMDBBlockchainDB.cpp
+++ b/src/CryptoNoteCore/LMDBBlockchainDB.cpp
@@ -935,9 +935,9 @@ bool LMDBBlockchainDB::findAccountRegistrationsByKeys(const uint8_t* spendKey, c
   checkRc(rc, "findAccountRegistrationsByKeys:open");
 
   MDB_val k{}, v{};
-  // Walk backwards from the end — canonical account number is the most recent registration
+  // Walk forward from the beginning — canonical account number is the first registration
   if (findFirst) {
-    rc = mdb_cursor_get(cursor, &k, &v, MDB_LAST);
+    rc = mdb_cursor_get(cursor, &k, &v, MDB_FIRST);
     while (rc == 0) {
       if (v.mv_size == 64) {
         const uint8_t* data = static_cast<const uint8_t*>(v.mv_data);
@@ -948,7 +948,7 @@ bool LMDBBlockchainDB::findAccountRegistrationsByKeys(const uint8_t* spendKey, c
           break;
         }
       }
-      rc = mdb_cursor_get(cursor, &k, &v, MDB_PREV);
+      rc = mdb_cursor_get(cursor, &k, &v, MDB_NEXT);
     }
   } else {
     // Full scan from beginning

--- a/src/CryptoNoteCore/LMDBBlockchainDB.cpp
+++ b/src/CryptoNoteCore/LMDBBlockchainDB.cpp
@@ -134,6 +134,7 @@ bool LMDBBlockchainDB::open(const std::string& path) {
     openDb(setupTxn, "payment_id_idx",    MDB_DUPSORT | MDB_DUPFIXED, m_dbiPaymentIdIdx);
     openDb(setupTxn, "timestamp_idx",     0,                         m_dbiTimestampIdx);
     openDb(setupTxn, "gen_tx_idx",        0,                         m_dbiGenTxIdx);
+    openDb(setupTxn, "acct_reg",          0,                         m_dbiAccountRegistrations);
   } catch (...) {
     mdb_txn_abort(setupTxn);
     mdb_env_close(m_env);
@@ -186,6 +187,7 @@ void LMDBBlockchainDB::clear() {
   dropDb(m_dbiPaymentIdIdx);
   dropDb(m_dbiTimestampIdx);
   dropDb(m_dbiGenTxIdx);
+  dropDb(m_dbiAccountRegistrations);
 
   rc = mdb_txn_commit(txn);
   checkRc(rc, "clear:commit");
@@ -797,6 +799,114 @@ bool LMDBBlockchainDB::removeGeneratedTxCount(uint32_t height) {
   if (rc == MDB_NOTFOUND) return false;
   checkRc(rc, "removeGeneratedTxCount");
   return true;
+}
+
+// ─── account_registrations ────────────────────────────────────────────────
+
+// Big-endian key encoding so LMDB sort order = block height order.
+// Only used for acct_reg table; other tables use native byte order.
+static void packAcctRegKey(uint32_t blockHeight, uint32_t txIndex, uint8_t out[8]) {
+  out[0] = static_cast<uint8_t>(blockHeight >> 24);
+  out[1] = static_cast<uint8_t>(blockHeight >> 16);
+  out[2] = static_cast<uint8_t>(blockHeight >>  8);
+  out[3] = static_cast<uint8_t>(blockHeight);
+  out[4] = static_cast<uint8_t>(txIndex >> 24);
+  out[5] = static_cast<uint8_t>(txIndex >> 16);
+  out[6] = static_cast<uint8_t>(txIndex >>  8);
+  out[7] = static_cast<uint8_t>(txIndex);
+}
+
+static void unpackAcctRegKey(const uint8_t in[8], uint32_t& blockHeight, uint32_t& txIndex) {
+  blockHeight = (static_cast<uint32_t>(in[0]) << 24) | (static_cast<uint32_t>(in[1]) << 16) |
+                (static_cast<uint32_t>(in[2]) <<  8) |  static_cast<uint32_t>(in[3]);
+  txIndex     = (static_cast<uint32_t>(in[4]) << 24) | (static_cast<uint32_t>(in[5]) << 16) |
+                (static_cast<uint32_t>(in[6]) <<  8) |  static_cast<uint32_t>(in[7]);
+}
+
+bool LMDBBlockchainDB::putAccountRegistration(uint32_t blockHeight, uint32_t txIndex,
+                                              const uint8_t* spendKey, const uint8_t* viewKey) {
+  assert(m_writeTxn);
+  uint8_t keyBuf[8];
+  packAcctRegKey(blockHeight, txIndex, keyBuf);
+  uint8_t valueBuf[64];
+  memcpy(valueBuf, spendKey, 32);
+  memcpy(valueBuf + 32, viewKey, 32);
+  MDB_val k = {sizeof(keyBuf), keyBuf};
+  MDB_val v = {64, valueBuf};
+  int rc = mdb_put(m_writeTxn, m_dbiAccountRegistrations, &k, &v, 0);
+  checkRc(rc, "putAccountRegistration");
+  return true;
+}
+
+bool LMDBBlockchainDB::getAccountRegistration(uint32_t blockHeight, uint32_t txIndex,
+                                              uint8_t* spendKey, uint8_t* viewKey) const {
+  auto guard = readTxn();
+  uint8_t keyBuf[8];
+  packAcctRegKey(blockHeight, txIndex, keyBuf);
+  MDB_val k = {sizeof(keyBuf), keyBuf}, v{};
+  int rc = mdb_get(guard.txn, m_dbiAccountRegistrations, &k, &v);
+  if (rc == MDB_NOTFOUND) return false;
+  checkRc(rc, "getAccountRegistration");
+  if (v.mv_size != 64) return false;
+  memcpy(spendKey, v.mv_data, 32);
+  memcpy(viewKey, static_cast<const uint8_t*>(v.mv_data) + 32, 32);
+  return true;
+}
+
+bool LMDBBlockchainDB::removeAccountRegistration(uint32_t blockHeight, uint32_t txIndex) {
+  assert(m_writeTxn);
+  uint8_t keyBuf[8];
+  packAcctRegKey(blockHeight, txIndex, keyBuf);
+  MDB_val k = {sizeof(keyBuf), keyBuf};
+  int rc = mdb_del(m_writeTxn, m_dbiAccountRegistrations, &k, nullptr);
+  if (rc == MDB_NOTFOUND) return false;
+  checkRc(rc, "removeAccountRegistration");
+  return true;
+}
+
+bool LMDBBlockchainDB::findAccountRegistrationsByKeys(const uint8_t* spendKey, const uint8_t* viewKey,
+                                                      bool findFirst,
+                                                      std::vector<std::pair<uint32_t, uint32_t>>& results) const {
+  results.clear();
+  auto guard = readTxn();
+  MDB_cursor* cursor = nullptr;
+  int rc = mdb_cursor_open(guard.txn, m_dbiAccountRegistrations, &cursor);
+  checkRc(rc, "findAccountRegistrationsByKeys:open");
+
+  MDB_val k{}, v{};
+  // Walk backwards from the end (newest first) for canonical lookup
+  if (findFirst) {
+    rc = mdb_cursor_get(cursor, &k, &v, MDB_LAST);
+    while (rc == 0) {
+      if (v.mv_size == 64) {
+        const uint8_t* data = static_cast<const uint8_t*>(v.mv_data);
+        if (memcmp(data, spendKey, 32) == 0 && memcmp(data + 32, viewKey, 32) == 0) {
+          uint32_t h, i;
+          unpackAcctRegKey(static_cast<const uint8_t*>(k.mv_data), h, i);
+          results.push_back({h, i});
+          break;
+        }
+      }
+      rc = mdb_cursor_get(cursor, &k, &v, MDB_PREV);
+    }
+  } else {
+    // Full scan from beginning
+    rc = mdb_cursor_get(cursor, &k, &v, MDB_FIRST);
+    while (rc == 0) {
+      if (v.mv_size == 64) {
+        const uint8_t* data = static_cast<const uint8_t*>(v.mv_data);
+        if (memcmp(data, spendKey, 32) == 0 && memcmp(data + 32, viewKey, 32) == 0) {
+          uint32_t h, i;
+          unpackAcctRegKey(static_cast<const uint8_t*>(k.mv_data), h, i);
+          results.push_back({h, i});
+        }
+      }
+      rc = mdb_cursor_get(cursor, &k, &v, MDB_NEXT);
+    }
+  }
+
+  mdb_cursor_close(cursor);
+  return !results.empty();
 }
 
 } // namespace CryptoNote

--- a/src/CryptoNoteCore/LMDBBlockchainDB.h
+++ b/src/CryptoNoteCore/LMDBBlockchainDB.h
@@ -144,6 +144,22 @@ public:
   bool getGeneratedTxCount(uint32_t height, uint64_t& count) const;
   bool removeGeneratedTxCount(uint32_t height);
 
+  // ── account_registrations ───────────────────────────────────────────────
+  // Key: uint64_t packed as blockHeight << 32 | txIndex (native byte order)
+  // Value: 64 bytes — spend pubkey (32) || view pubkey (32)
+  bool putAccountRegistration(uint32_t blockHeight, uint32_t txIndex,
+                              const uint8_t* spendKey, const uint8_t* viewKey);
+  bool getAccountRegistration(uint32_t blockHeight, uint32_t txIndex,
+                              uint8_t* spendKey, uint8_t* viewKey) const;
+  bool removeAccountRegistration(uint32_t blockHeight, uint32_t txIndex);
+
+  // Reverse lookup: find registrations matching given spend+view keys.
+  // If findFirst is true, walks cursor backwards and stops at first match (canonical).
+  // If findFirst is false, scans entire table collecting all matches.
+  bool findAccountRegistrationsByKeys(const uint8_t* spendKey, const uint8_t* viewKey,
+                                      bool findFirst,
+                                      std::vector<std::pair<uint32_t, uint32_t>>& results) const;
+
   // ── Resize when map is full ───────────────────────────────────────────────
   // Call this when no write txn is active, then re-begin the txn.
   void resizeMap();
@@ -185,6 +201,7 @@ private:
   MDB_dbi m_dbiPaymentIdIdx;
   MDB_dbi m_dbiTimestampIdx;
   MDB_dbi m_dbiGenTxIdx;
+  MDB_dbi m_dbiAccountRegistrations;
 
   // RAII guard for read transactions.  If a write txn is active the guard
   // borrows it (no cleanup); otherwise it opens a temporary read-only txn

--- a/src/CryptoNoteCore/LMDBBlockchainDB.h
+++ b/src/CryptoNoteCore/LMDBBlockchainDB.h
@@ -161,12 +161,9 @@ public:
                               uint8_t* spendKey, uint8_t* viewKey) const;
   bool removeAccountRegistration(uint32_t blockHeight, uint32_t txIndex);
 
-  // Reverse lookup: find registrations matching given spend+view keys.
-  // If findFirst is true, walks cursor backwards and stops at first match (canonical).
-  // If findFirst is false, scans entire table collecting all matches.
-  bool findAccountRegistrationsByKeys(const uint8_t* spendKey, const uint8_t* viewKey,
-                                      bool findFirst,
-                                      std::vector<std::pair<uint32_t, uint32_t>>& results) const;
+  // Reverse lookup: find the first (canonical) registration matching given spend+view keys.
+  bool findAccountRegistrationByKeys(const uint8_t* spendKey, const uint8_t* viewKey,
+                                     uint32_t& blockHeight, uint32_t& txIndex) const;
 
   // ── Resize when map is full ───────────────────────────────────────────────
   // Call this when no write txn is active, then re-begin the txn.

--- a/src/CryptoNoteCore/TransactionExtra.cpp
+++ b/src/CryptoNoteCore/TransactionExtra.cpp
@@ -86,6 +86,14 @@ bool parseTransactionExtra(const std::vector<uint8_t> &transactionExtra, std::ve
         transactionExtraFields.push_back(mmTag);
         break;
       }
+
+      case TX_EXTRA_TAG_ACCOUNT_REGISTRATION: {
+        TransactionExtraAccountRegistration reg;
+        ar(reg.spendPublicKey, "spend_public_key");
+        ar(reg.viewPublicKey, "view_public_key");
+        transactionExtraFields.push_back(reg);
+        break;
+      }
       }
     }
   } catch (std::exception &) {
@@ -119,6 +127,10 @@ struct ExtraSerializerVisitor : public boost::static_visitor<bool> {
 
   bool operator()(const TransactionExtraMergeMiningTag& t) {
     return appendMergeMiningTagToExtra(extra, t);
+  }
+
+  bool operator()(const TransactionExtraAccountRegistration& t) {
+    return addAccountRegistrationToExtra(extra, t.spendPublicKey, t.viewPublicKey);
   }
 };
 
@@ -242,6 +254,23 @@ bool getPaymentIdFromTxExtra(const std::vector<uint8_t>& extra, Hash& paymentId)
   }
 
   return true;
+}
+
+bool addAccountRegistrationToExtra(std::vector<uint8_t>& tx_extra, const PublicKey& spendKey, const PublicKey& viewKey) {
+  size_t start = tx_extra.size();
+  tx_extra.resize(start + 1 + sizeof(PublicKey) + sizeof(PublicKey));
+  tx_extra[start] = TX_EXTRA_TAG_ACCOUNT_REGISTRATION;
+  memcpy(&tx_extra[start + 1], &spendKey, sizeof(PublicKey));
+  memcpy(&tx_extra[start + 1 + sizeof(PublicKey)], &viewKey, sizeof(PublicKey));
+  return true;
+}
+
+bool getAccountRegistrationFromExtra(const std::vector<uint8_t>& tx_extra, TransactionExtraAccountRegistration& reg) {
+  std::vector<TransactionExtraField> tx_extra_fields;
+  if (!parseTransactionExtra(tx_extra, tx_extra_fields)) {
+    return false;
+  }
+  return findTransactionExtraFieldByType(tx_extra_fields, reg);
 }
 
 

--- a/src/CryptoNoteCore/TransactionExtra.cpp
+++ b/src/CryptoNoteCore/TransactionExtra.cpp
@@ -22,6 +22,7 @@
 #include "Common/StreamTools.h"
 #include "Common/StringTools.h"
 #include "CryptoNoteTools.h"
+#include "../crypto/crypto.h"
 #include "Serialization/BinaryOutputStreamSerializer.h"
 #include "Serialization/BinaryInputStreamSerializer.h"
 
@@ -271,6 +272,46 @@ bool getAccountRegistrationFromExtra(const std::vector<uint8_t>& tx_extra, Trans
     return false;
   }
   return findTransactionExtraFieldByType(tx_extra_fields, reg);
+}
+
+bool isWellFormedAccountRegistration(const std::vector<uint8_t>& tx_extra) {
+  std::vector<TransactionExtraField> extraFields;
+  if (!parseTransactionExtra(tx_extra, extraFields)) {
+    return false;
+  }
+
+  int regCount = 0;
+  bool hasNonce = false;
+  for (const auto& field : extraFields) {
+    if (field.type() == typeid(TransactionExtraAccountRegistration)) {
+      ++regCount;
+    }
+    if (field.type() == typeid(TransactionExtraNonce)) {
+      hasNonce = true;
+    }
+  }
+
+  if (regCount != 1) {
+    return false;
+  }
+
+  if (hasNonce) {
+    return false;
+  }
+
+  TransactionExtraAccountRegistration reg;
+  findTransactionExtraFieldByType(extraFields, reg);
+
+  if (!Crypto::check_key(reg.spendPublicKey) || !Crypto::check_key(reg.viewPublicKey)) {
+    return false;
+  }
+
+  static const Crypto::PublicKey identity = {};
+  if (reg.spendPublicKey == identity || reg.viewPublicKey == identity) {
+    return false;
+  }
+
+  return true;
 }
 
 

--- a/src/CryptoNoteCore/TransactionExtra.h
+++ b/src/CryptoNoteCore/TransactionExtra.h
@@ -31,6 +31,7 @@
 #define TX_EXTRA_TAG_PUBKEY                 0x01
 #define TX_EXTRA_NONCE                      0x02
 #define TX_EXTRA_MERGE_MINING_TAG           0x03
+#define TX_EXTRA_TAG_ACCOUNT_REGISTRATION  0x04
 
 #define TX_EXTRA_NONCE_PAYMENT_ID           0x00
 
@@ -53,11 +54,16 @@ struct TransactionExtraMergeMiningTag {
   Crypto::Hash merkleRoot;
 };
 
+struct TransactionExtraAccountRegistration {
+  Crypto::PublicKey spendPublicKey;
+  Crypto::PublicKey viewPublicKey;
+};
+
 // tx_extra_field format, except tx_extra_padding and tx_extra_pub_key:
 //   varint tag;
 //   varint size;
 //   varint data[];
-typedef boost::variant<TransactionExtraPadding, TransactionExtraPublicKey, TransactionExtraNonce, TransactionExtraMergeMiningTag> TransactionExtraField;
+typedef boost::variant<TransactionExtraPadding, TransactionExtraPublicKey, TransactionExtraNonce, TransactionExtraMergeMiningTag, TransactionExtraAccountRegistration> TransactionExtraField;
 
 
 
@@ -88,5 +94,8 @@ bool createTxExtraWithPaymentId(const std::string& paymentIdString, std::vector<
 //returns false if payment id is not found or parse error
 bool getPaymentIdFromTxExtra(const std::vector<uint8_t>& extra, Crypto::Hash& paymentId);
 bool parsePaymentId(const std::string& paymentIdString, Crypto::Hash& paymentId);
+
+bool addAccountRegistrationToExtra(std::vector<uint8_t>& tx_extra, const Crypto::PublicKey& spendKey, const Crypto::PublicKey& viewKey);
+bool getAccountRegistrationFromExtra(const std::vector<uint8_t>& tx_extra, TransactionExtraAccountRegistration& reg);
 
 }

--- a/src/CryptoNoteCore/TransactionExtra.h
+++ b/src/CryptoNoteCore/TransactionExtra.h
@@ -31,7 +31,7 @@
 #define TX_EXTRA_TAG_PUBKEY                 0x01
 #define TX_EXTRA_NONCE                      0x02
 #define TX_EXTRA_MERGE_MINING_TAG           0x03
-#define TX_EXTRA_TAG_ACCOUNT_REGISTRATION  0x04
+#define TX_EXTRA_TAG_ACCOUNT_REGISTRATION   0x04
 
 #define TX_EXTRA_NONCE_PAYMENT_ID           0x00
 

--- a/src/CryptoNoteCore/TransactionExtra.h
+++ b/src/CryptoNoteCore/TransactionExtra.h
@@ -97,5 +97,6 @@ bool parsePaymentId(const std::string& paymentIdString, Crypto::Hash& paymentId)
 
 bool addAccountRegistrationToExtra(std::vector<uint8_t>& tx_extra, const Crypto::PublicKey& spendKey, const Crypto::PublicKey& viewKey);
 bool getAccountRegistrationFromExtra(const std::vector<uint8_t>& tx_extra, TransactionExtraAccountRegistration& reg);
+bool isWellFormedAccountRegistration(const std::vector<uint8_t>& tx_extra);
 
 }

--- a/src/GreenWallet/CommandDispatcher.cpp
+++ b/src/GreenWallet/CommandDispatcher.cpp
@@ -25,6 +25,22 @@ bool handleCommand(const std::string command,
     else if (command == "address")
     {
         std::cout << SuccessMsg(walletInfo->walletAddress) << std::endl;
+
+        /* Check if this address has a registered account number */
+        std::string accountNumber;
+        if (getAccountNumberViaNode(node, walletInfo->walletAddress, accountNumber))
+        {
+            std::cout << InformationMsg("Account number: ")
+                      << SuccessMsg(accountNumber) << std::endl;
+        }
+        else
+        {
+            std::cout << InformationMsg("No account number registered for this address.") << std::endl;
+            if (!walletInfo->viewWallet)
+            {
+                std::cout << InformationMsg("You can register one with the 'register_account' command.") << std::endl;
+            }
+        }
     }
     else if (command == "balance")
     {
@@ -119,6 +135,10 @@ bool handleCommand(const std::string command,
     else if (command == "verify_message")
     {
       verifyMessage(walletInfo->wallet);
+    }
+    else if (command == "register_account")
+    {
+        registerAccountNumber(walletInfo, node);
     }
     /* This should never happen */
     else

--- a/src/GreenWallet/CommandImplementations.cpp
+++ b/src/GreenWallet/CommandImplementations.cpp
@@ -14,12 +14,16 @@
 #include "Common/FormatTools.h"
 #include "CryptoNoteCore/Account.h"
 #include "CryptoNoteCore/CryptoNoteBasicImpl.h"
+#include "CryptoNoteCore/TransactionExtra.h"
+#include <GreenWallet/Transfer.h>
 
 #ifndef MSVC
 #include <fstream>
 #endif
 
 #include "Mnemonics/electrum-words.h"
+
+#include <future>
 
 #include <GreenWallet/AddressBook.h>
 #include <Common/ColouredMsg.h>
@@ -1056,5 +1060,87 @@ void verifyMessage(CryptoNote::WalletGreen &wallet)
         std::cout << WarningMsg("Failed to verify message: ")
                   << WarningMsg(e.what())
                   << std::endl;
+    }
+}
+
+void registerAccountNumber(std::shared_ptr<WalletInfo> walletInfo, CryptoNote::INode &node)
+{
+    if (walletInfo->viewWallet)
+    {
+        std::cout << WarningMsg("Cannot register account number from a view wallet.") << std::endl;
+        return;
+    }
+
+    /* Check if already registered */
+    std::string existingNumber;
+    if (getAccountNumberViaNode(node, walletInfo->walletAddress, existingNumber))
+    {
+        std::cout << WarningMsg("This address already has account number: ")
+                  << SuccessMsg(existingNumber) << std::endl;
+        std::cout << WarningMsg("Re-registering will create a new account number. "
+                                "The new number will become canonical.") << std::endl;
+        std::cout << "Proceed with re-registration? (y/N): ";
+
+        std::string confirm;
+        std::getline(std::cin, confirm);
+        if (confirm.empty() || (confirm[0] != 'y' && confirm[0] != 'Y'))
+        {
+            std::cout << WarningMsg("Cancelling registration.") << std::endl;
+            return;
+        }
+    }
+    else
+    {
+        std::cout << InformationMsg("You don't have an account number yet. "
+                                    "Register one for easy payments? (small fee applies)")
+                  << std::endl;
+        std::cout << "Proceed? (Y/n): ";
+
+        std::string confirm;
+        std::getline(std::cin, confirm);
+        if (!confirm.empty() && confirm[0] != 'y' && confirm[0] != 'Y')
+        {
+            std::cout << WarningMsg("Cancelling registration.") << std::endl;
+            return;
+        }
+    }
+
+    /* Build registration tx extra */
+    CryptoNote::AccountPublicAddress address = walletInfo->wallet.getAccountPublicAddress(0);
+
+    std::vector<uint8_t> extra;
+    CryptoNote::addAccountRegistrationToExtra(extra, address.spendPublicKey, address.viewPublicKey);
+
+    /* Send a minimal self-transfer with the registration extra */
+    try
+    {
+        CryptoNote::TransactionParameters params;
+        params.destinations.push_back({walletInfo->walletAddress, CryptoNote::parameters::DEFAULT_DUST_THRESHOLD});
+        params.fee = node.getMinimalFee();
+        params.extra = std::string(extra.begin(), extra.end());
+        params.sourceAddresses = {walletInfo->walletAddress};
+        params.changeDestination = walletInfo->walletAddress;
+
+        Crypto::SecretKey txSecretKey;
+        size_t txId = walletInfo->wallet.transfer(params, txSecretKey);
+
+        auto txHash = walletInfo->wallet.getTransaction(txId).hash;
+        std::cout << SuccessMsg("Account registration transaction sent!")
+                  << std::endl
+                  << SuccessMsg("Transaction hash: ")
+                  << Common::podToHex(txHash) << std::endl
+                  << InformationMsg("Your account number will be available "
+                                    "once the transaction is confirmed.")
+                  << std::endl;
+    }
+    catch (const std::system_error &e)
+    {
+        std::cout << WarningMsg("Failed to send registration transaction: ")
+                  << WarningMsg(e.what()) << std::endl;
+    }
+    catch (const std::exception &e)
+    {
+        std::cout << WarningMsg("Failed to send registration transaction: ")
+                  << WarningMsg(e.what()) << std::endl;
     }
 }

--- a/src/GreenWallet/CommandImplementations.cpp
+++ b/src/GreenWallet/CommandImplementations.cpp
@@ -1077,32 +1077,20 @@ void registerAccountNumber(std::shared_ptr<WalletInfo> walletInfo, CryptoNote::I
     {
         std::cout << WarningMsg("This address already has account number: ")
                   << SuccessMsg(existingNumber) << std::endl;
-        std::cout << WarningMsg("Re-registering will create a new account number. "
-                                "The new number will become canonical.") << std::endl;
-        std::cout << "Proceed with re-registration? (y/N): ";
-
-        std::string confirm;
-        std::getline(std::cin, confirm);
-        if (confirm.empty() || (confirm[0] != 'y' && confirm[0] != 'Y'))
-        {
-            std::cout << WarningMsg("Cancelling registration.") << std::endl;
-            return;
-        }
+        return;
     }
-    else
-    {
-        std::cout << InformationMsg("You don't have an account number yet. "
-                                    "Register one for easy payments? (small fee applies)")
-                  << std::endl;
-        std::cout << "Proceed? (Y/n): ";
 
-        std::string confirm;
-        std::getline(std::cin, confirm);
-        if (!confirm.empty() && confirm[0] != 'y' && confirm[0] != 'Y')
-        {
-            std::cout << WarningMsg("Cancelling registration.") << std::endl;
-            return;
-        }
+    std::cout << InformationMsg("Register an account number for easy payments? "
+                                "(small fee applies)")
+              << std::endl;
+    std::cout << "Proceed? (Y/n): ";
+
+    std::string confirm;
+    std::getline(std::cin, confirm);
+    if (!confirm.empty() && confirm[0] != 'y' && confirm[0] != 'Y')
+    {
+        std::cout << WarningMsg("Cancelling registration.") << std::endl;
+        return;
     }
 
     /* Build registration tx extra */

--- a/src/GreenWallet/CommandImplementations.h
+++ b/src/GreenWallet/CommandImplementations.h
@@ -69,3 +69,5 @@ void txProof(CryptoNote::WalletGreen &wallet);
 void signMessage(std::shared_ptr<WalletInfo> walletInfo, bool viewWallet);
 
 void verifyMessage(CryptoNote::WalletGreen &wallet);
+
+void registerAccountNumber(std::shared_ptr<WalletInfo> walletInfo, CryptoNote::INode &node);

--- a/src/GreenWallet/Commands.cpp
+++ b/src/GreenWallet/Commands.cpp
@@ -66,6 +66,7 @@ std::vector<AdvancedCommand> allCommands()
 		AdvancedCommand("tx_key", "Display transaction secret key if it's stored in wallet cache", false, true),
 		AdvancedCommand("tx_proof", "Display proof of payment to specified address", false, true),
 		AdvancedCommand("verify_message", "Verify signed message", true, true),
+		AdvancedCommand("register_account", "Register an account number for easy payments", false, true),
 	};
 }
 

--- a/src/GreenWallet/Transfer.cpp
+++ b/src/GreenWallet/Transfer.cpp
@@ -10,6 +10,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <chrono>
+#include <future>
 #include <thread>
 
 #include <Common/StringTools.h>
@@ -322,7 +323,34 @@ void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height, bool send
         return;
     }
 
-    const std::string address = maybeAddress.x;
+    std::string address = maybeAddress.x;
+
+    /* If the input is an account number, resolve it to an address */
+    if (isAccountNumber(address))
+    {
+        std::string resolvedAddress;
+        if (!resolveAccountNumberViaNode(walletInfo->wallet.getNode(), address, resolvedAddress))
+        {
+            std::cout << WarningMsg("Failed to resolve account number ") << address << std::endl;
+            return;
+        }
+
+        std::cout << InformationMsg("Account number ") << address
+                  << InformationMsg(" resolved to:") << std::endl
+                  << InformationMsg(resolvedAddress) << std::endl << std::endl;
+
+        std::cout << "Confirm sending to this address? (Y/n): ";
+        std::string confirm;
+        std::getline(std::cin, confirm);
+        boost::algorithm::trim(confirm);
+        if (!confirm.empty() && confirm[0] != 'Y' && confirm[0] != 'y')
+        {
+            std::cout << WarningMsg("Cancelling transaction.") << std::endl;
+            return;
+        }
+
+        address = resolvedAddress;
+    }
 
 
 
@@ -891,6 +919,12 @@ Maybe<std::string> getDestinationAddress()
             return Just<std::string>(transferAddr);
         }
 
+        /* Check if input is an account number (e.g. 1821033-7-K) */
+        if (isAccountNumber(transferAddr))
+        {
+            return Just<std::string>(transferAddr);
+        }
+
         if (std::cin.fail() || std::cin.eof()) {
             std::cin.clear();
         }
@@ -1108,3 +1142,33 @@ bool askAliasesTransfersConfirmation(const std::string address)
     return answer == "y" || answer == "Y";
 }
 #endif
+
+bool isAccountNumber(const std::string& input)
+{
+    CryptoNote::AccountNumber acctNum;
+    return CryptoNote::AccountNumber::fromString(input, acctNum);
+}
+
+bool resolveAccountNumberViaNode(CryptoNote::INode& node, const std::string& accountNumber, std::string& address)
+{
+    std::promise<std::error_code> promise;
+    auto future = promise.get_future();
+
+    node.resolveAccountNumber(accountNumber, address,
+        [&promise](std::error_code ec) { promise.set_value(ec); });
+
+    auto ec = future.get();
+    return !ec && !address.empty();
+}
+
+bool getAccountNumberViaNode(CryptoNote::INode& node, const std::string& address, std::string& accountNumber)
+{
+    std::promise<std::error_code> promise;
+    auto future = promise.get_future();
+
+    node.getAccountNumber(address, accountNumber,
+        [&promise](std::error_code ec) { promise.set_value(ec); });
+
+    auto ec = future.get();
+    return !ec && !accountNumber.empty();
+}

--- a/src/GreenWallet/Transfer.h
+++ b/src/GreenWallet/Transfer.h
@@ -6,9 +6,12 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <GreenWallet/Types.h>
 #include <GreenWallet/WalletConfig.h>
+#include <CryptoNoteCore/AccountNumber.h>
+#include <INode.h>
 
 enum BalanceInfo { NotEnoughBalance, EnoughBalance, SetMixinToZero };
 void transfer(std::shared_ptr<WalletInfo> walletInfo, uint32_t height,
@@ -56,6 +59,12 @@ Maybe<std::string> getPaymentID(std::string msg);
 Maybe<std::string> getExtra();
 
 Maybe<std::string> getDestinationAddress();
+
+bool isAccountNumber(const std::string& input);
+
+bool resolveAccountNumberViaNode(CryptoNote::INode& node, const std::string& accountNumber, std::string& address);
+
+bool getAccountNumberViaNode(CryptoNote::INode& node, const std::string& address, std::string& accountNumber);
 
 Maybe<uint64_t> getFee();
 

--- a/src/InProcessNode/InProcessNode.cpp
+++ b/src/InProcessNode/InProcessNode.cpp
@@ -25,6 +25,8 @@
 #include "CryptoNoteConfig.h"
 #include "Common/Math.h"
 #include "Common/StringTools.h"
+#include "CryptoNoteCore/AccountNumber.h"
+#include "CryptoNoteCore/CryptoNoteBasicImpl.h"
 #include "CryptoNoteCore/CryptoNoteTools.h"
 #include "CryptoNoteCore/IBlock.h"
 #include "CryptoNoteCore/VerificationContext.h"
@@ -1285,6 +1287,78 @@ std::error_code InProcessNode::doGetConnections(std::vector<p2pConnection>& conn
   }
 
   return std::error_code();
+}
+
+void InProcessNode::resolveAccountNumber(const std::string& accountNumber, std::string& address, const Callback& callback) {
+  std::unique_lock<std::mutex> lock(mutex);
+  if (state != INITIALIZED) {
+    lock.unlock();
+    callback(make_error_code(CryptoNote::error::NOT_INITIALIZED));
+    return;
+  }
+
+  ioService.post(
+    std::bind(&InProcessNode::resolveAccountNumberAsync,
+      this,
+      std::cref(accountNumber),
+      std::ref(address),
+      callback
+    )
+  );
+}
+
+void InProcessNode::resolveAccountNumberAsync(const std::string& accountNumber, std::string& address, const Callback& callback) {
+  AccountNumber acctNum;
+  if (!AccountNumber::fromString(accountNumber, acctNum)) {
+    callback(std::make_error_code(std::errc::invalid_argument));
+    return;
+  }
+
+  AccountPublicAddress addr;
+  if (!core.resolveAccountNumber(acctNum.blockHeight, acctNum.txIndex, addr)) {
+    callback(std::make_error_code(std::errc::no_such_file_or_directory));
+    return;
+  }
+
+  address = getAccountAddressAsStr(parameters::CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX, addr);
+  callback(std::error_code());
+}
+
+void InProcessNode::getAccountNumber(const std::string& address, std::string& accountNumber, const Callback& callback) {
+  std::unique_lock<std::mutex> lock(mutex);
+  if (state != INITIALIZED) {
+    lock.unlock();
+    callback(make_error_code(CryptoNote::error::NOT_INITIALIZED));
+    return;
+  }
+
+  ioService.post(
+    std::bind(&InProcessNode::getAccountNumberAsync,
+      this,
+      std::cref(address),
+      std::ref(accountNumber),
+      callback
+    )
+  );
+}
+
+void InProcessNode::getAccountNumberAsync(const std::string& address, std::string& accountNumber, const Callback& callback) {
+  AccountPublicAddress addr;
+  uint64_t prefix;
+  if (!parseAccountAddressString(prefix, addr, address)) {
+    callback(std::make_error_code(std::errc::invalid_argument));
+    return;
+  }
+
+  uint32_t blockHeight, txIndex;
+  if (!core.getAccountNumber(addr, blockHeight, txIndex)) {
+    callback(std::make_error_code(std::errc::no_such_file_or_directory));
+    return;
+  }
+
+  AccountNumber acctNum{blockHeight, txIndex};
+  accountNumber = acctNum.toString();
+  callback(std::error_code());
 }
 
 } //namespace CryptoNote

--- a/src/InProcessNode/InProcessNode.cpp
+++ b/src/InProcessNode/InProcessNode.cpp
@@ -19,6 +19,7 @@
 #include "InProcessNode.h"
 
 #include <functional>
+#include <limits>
 #include <boost/utility/value_init.hpp>
 #include <CryptoNoteCore/TransactionApi.h>
 
@@ -1310,6 +1311,12 @@ void InProcessNode::resolveAccountNumber(const std::string& accountNumber, std::
 void InProcessNode::resolveAccountNumberAsync(const std::string& accountNumber, std::string& address, const Callback& callback) {
   AccountNumber acctNum;
   if (!AccountNumber::fromString(accountNumber, acctNum)) {
+    callback(std::make_error_code(std::errc::invalid_argument));
+    return;
+  }
+  if (acctNum.txIndex == 0 ||
+      acctNum.txIndex > std::numeric_limits<uint16_t>::max() ||
+      acctNum.blockHeight >= core.getCurrentBlockchainHeight()) {
     callback(std::make_error_code(std::errc::invalid_argument));
     return;
   }

--- a/src/InProcessNode/InProcessNode.h
+++ b/src/InProcessNode/InProcessNode.h
@@ -98,6 +98,9 @@ public:
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
   virtual void getConnections(std::vector<p2pConnection>& connections, const Callback& callback) override;
 
+  virtual void resolveAccountNumber(const std::string& accountNumber, std::string& address, const Callback& callback) override;
+  virtual void getAccountNumber(const std::string& address, std::string& accountNumber, const Callback& callback) override;
+
   virtual void setRootCert(const std::string &path) override;
   virtual void disableVerify() override;
 
@@ -159,6 +162,9 @@ private:
 
   void getConnectionsAsync(std::vector<p2pConnection>& connections, const Callback& callback);
   std::error_code doGetConnections(std::vector<p2pConnection>& connections);
+
+  void resolveAccountNumberAsync(const std::string& accountNumber, std::string& address, const Callback& callback);
+  void getAccountNumberAsync(const std::string& address, std::string& accountNumber, const Callback& callback);
 
   void workerFunc();
   bool doShutdown();

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -1038,7 +1038,7 @@ std::error_code NodeRpcProxy::doResolveAccountNumber(const std::string& accountN
   COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request req = AUTO_VAL_INIT(req);
   COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response rsp = AUTO_VAL_INIT(rsp);
   req.account_number = accountNumber;
-  std::error_code ec = jsonRpcCommand("resolve_account_number", req, rsp);
+  std::error_code ec = jsonRpcCommand("resolveaccountnumber", req, rsp);
   if (!ec) {
     address = rsp.address;
   }
@@ -1059,7 +1059,7 @@ std::error_code NodeRpcProxy::doGetAccountNumber(const std::string& address, std
   COMMAND_RPC_GET_ACCOUNT_NUMBER::request req = AUTO_VAL_INIT(req);
   COMMAND_RPC_GET_ACCOUNT_NUMBER::response rsp = AUTO_VAL_INIT(rsp);
   req.address = address;
-  std::error_code ec = jsonRpcCommand("get_account_number", req, rsp);
+  std::error_code ec = jsonRpcCommand("getaccountnumber", req, rsp);
   if (!ec) {
     accountNumber = rsp.account_number;
   }

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -1024,4 +1024,46 @@ std::error_code NodeRpcProxy::jsonRpcCommand(const std::string& method, const Re
   return ec;
 }
 
+void NodeRpcProxy::resolveAccountNumber(const std::string& accountNumber, std::string& address, const Callback& callback) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_state != STATE_INITIALIZED) {
+    callback(make_error_code(error::NOT_INITIALIZED));
+    return;
+  }
+
+  scheduleRequest(std::bind(&NodeRpcProxy::doResolveAccountNumber, this, accountNumber, std::ref(address)), callback);
+}
+
+std::error_code NodeRpcProxy::doResolveAccountNumber(const std::string& accountNumber, std::string& address) {
+  COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response rsp = AUTO_VAL_INIT(rsp);
+  req.account_number = accountNumber;
+  std::error_code ec = jsonRpcCommand("resolve_account_number", req, rsp);
+  if (!ec) {
+    address = rsp.address;
+  }
+  return ec;
+}
+
+void NodeRpcProxy::getAccountNumber(const std::string& address, std::string& accountNumber, const Callback& callback) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_state != STATE_INITIALIZED) {
+    callback(make_error_code(error::NOT_INITIALIZED));
+    return;
+  }
+
+  scheduleRequest(std::bind(&NodeRpcProxy::doGetAccountNumber, this, address, std::ref(accountNumber)), callback);
+}
+
+std::error_code NodeRpcProxy::doGetAccountNumber(const std::string& address, std::string& accountNumber) {
+  COMMAND_RPC_GET_ACCOUNT_NUMBER::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_ACCOUNT_NUMBER::response rsp = AUTO_VAL_INIT(rsp);
+  req.address = address;
+  std::error_code ec = jsonRpcCommand("get_account_number", req, rsp);
+  if (!ec) {
+    accountNumber = rsp.account_number;
+  }
+  return ec;
+}
+
 }

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -100,6 +100,9 @@ public:
   virtual void isSynchronized(bool& syncStatus, const Callback& callback) override;
   virtual void getConnections(std::vector<p2pConnection>& connections, const Callback& callback) override;
 
+  virtual void resolveAccountNumber(const std::string& accountNumber, std::string& address, const Callback& callback) override;
+  virtual void getAccountNumber(const std::string& address, std::string& accountNumber, const Callback& callback) override;
+
   virtual std::string feeAddress() const override;
   virtual uint64_t feeAmount() const override;
 
@@ -145,6 +148,8 @@ private:
   std::error_code doGetTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions);
   std::error_code doGetBlockTimestamp(uint32_t height, uint64_t& timestamp);
   std::error_code doGetConnections(std::vector<p2pConnection>& connections);
+  std::error_code doResolveAccountNumber(const std::string& accountNumber, std::string& address);
+  std::error_code doGetAccountNumber(const std::string& address, std::string& accountNumber);
 
   void scheduleRequest(std::function<std::error_code()>&& procedure, const Callback& callback);
   template <typename Request, typename Response>

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -1502,36 +1502,4 @@ struct COMMAND_RPC_GET_ACCOUNT_NUMBER {
   };
 };
 
-struct account_number_entry {
-  uint32_t block_height;
-  uint32_t tx_index;
-  std::string account_number;
-
-  void serialize(ISerializer& s) {
-    KV_MEMBER(block_height)
-    KV_MEMBER(tx_index)
-    KV_MEMBER(account_number)
-  }
-};
-
-struct COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS {
-  struct request {
-    std::string address;
-
-    void serialize(ISerializer& s) {
-      KV_MEMBER(address)
-    }
-  };
-
-  struct response {
-    std::vector<account_number_entry> entries;
-    std::string status;
-
-    void serialize(ISerializer& s) {
-      KV_MEMBER(entries)
-      KV_MEMBER(status)
-    }
-  };
-};
-
 }

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -357,6 +357,30 @@ struct COMMAND_EXPLORER_GET_TRANSACTIONS_BY_PAYMENT_ID {
   typedef std::string response;
 };
 
+struct COMMAND_EXPLORER_GET_ACCOUNT_NUMBER {
+  struct request {
+    std::string account_number;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(account_number)
+    }
+  };
+
+  typedef std::string response;
+};
+
+struct COMMAND_EXPLORER_GET_ADDRESS {
+  struct request {
+    std::string address;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(address)
+    }
+  };
+
+  typedef std::string response;
+};
+
 struct COMMAND_RPC_EXPLORER_SEARCH {
   struct request {
     std::string query;
@@ -1434,6 +1458,78 @@ struct COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID {
       KV_MEMBER(transaction_hashes);
       KV_MEMBER(received_amount);
       KV_MEMBER(confirmations);
+    }
+  };
+};
+
+struct COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER {
+  struct request {
+    std::string account_number;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(account_number)
+    }
+  };
+
+  struct response {
+    std::string address;
+    std::string status;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(address)
+      KV_MEMBER(status)
+    }
+  };
+};
+
+struct COMMAND_RPC_GET_ACCOUNT_NUMBER {
+  struct request {
+    std::string address;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(address)
+    }
+  };
+
+  struct response {
+    std::string account_number;
+    std::string status;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(account_number)
+      KV_MEMBER(status)
+    }
+  };
+};
+
+struct account_number_entry {
+  uint32_t block_height;
+  uint32_t tx_index;
+  std::string account_number;
+
+  void serialize(ISerializer& s) {
+    KV_MEMBER(block_height)
+    KV_MEMBER(tx_index)
+    KV_MEMBER(account_number)
+  }
+};
+
+struct COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS {
+  struct request {
+    std::string address;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(address)
+    }
+  };
+
+  struct response {
+    std::vector<account_number_entry> entries;
+    std::string status;
+
+    void serialize(ISerializer& s) {
+      KV_MEMBER(entries)
+      KV_MEMBER(status)
     }
   };
 };

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -708,8 +708,8 @@ bool RpcServer::processJsonRpcRequest(const CryptoNote::HttpRequest& request, Cr
       { "submitblock", { makeMemberMethod(&RpcServer::on_submitblock), false } },
       { "resolveopenalias", { makeMemberMethod(&RpcServer::on_resolve_open_alias), true } },
       { "search", { makeMemberMethod(&RpcServer::on_explorer_search), true } },
-      { "resolve_account_number", { makeMemberMethod(&RpcServer::on_resolve_account_number), true } },
-      { "get_account_number", { makeMemberMethod(&RpcServer::on_get_account_number), true } },
+      { "resolveaccountnumber", { makeMemberMethod(&RpcServer::on_resolve_account_number), true } },
+      { "getaccountnumber", { makeMemberMethod(&RpcServer::on_get_account_number), true } },
 
     };
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -23,6 +23,7 @@
 #include "version.h"
 
 #include <future>
+#include <limits>
 #include <unordered_map>
 #include <time.h>
 #include <boost/lexical_cast.hpp>
@@ -3466,6 +3467,11 @@ bool RpcServer::on_resolve_account_number(const COMMAND_RPC_RESOLVE_ACCOUNT_NUMB
                                           COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response& res) {
   AccountNumber acctNum;
   if (!AccountNumber::fromString(req.account_number, acctNum)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Invalid account number format" };
+  }
+  if (acctNum.txIndex == 0 ||
+      acctNum.txIndex > std::numeric_limits<uint16_t>::max() ||
+      acctNum.blockHeight >= m_core.getCurrentBlockchainHeight()) {
     throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Invalid account number format" };
   }
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -29,6 +29,7 @@
 #include <boost/uuid/uuid.hpp>
 
 // CryptoNote
+#include <crypto/crypto.h>
 #include <crypto/random.h>
 #include "BlockchainExplorerData.h"
 #include "Common/Base58.h"
@@ -43,6 +44,8 @@
 #include "CryptoNoteCore/IBlock.h"
 #include "CryptoNoteCore/Miner.h"
 #include "CryptoNoteCore/TransactionExtra.h"
+#include "CryptoNoteCore/AccountNumber.h"
+#include "CryptoNoteCore/CryptoNoteBasicImpl.h"
 #include "CryptoNoteProtocol/ICryptoNoteProtocolQuery.h"
 #include "P2p/ConnectionContext.h"
 #include "P2p/NetNode.h"
@@ -550,6 +553,50 @@ void RpcServer::processRequest(const CryptoNote::HttpRequest& request, CryptoNot
           return;
         }
 
+        std::string account_method = "/explorer/account/";
+        if (Common::starts_with(url, account_method)) {
+          std::string account_str = url.substr(account_method.size());
+
+          COMMAND_EXPLORER_GET_ACCOUNT_NUMBER::request req;
+          req.account_number = account_str;
+          COMMAND_EXPLORER_GET_ACCOUNT_NUMBER::response rsp;
+
+          bool r = on_get_explorer_account_number(req, rsp);
+          if (r) {
+            response.setStatus(CryptoNote::HttpResponse::STATUS_200);
+            response.setBody(rsp);
+          }
+          else {
+            response.setStatus(CryptoNote::HttpResponse::STATUS_404);
+            response.setBody("Not found");
+          }
+          response.addHeader("Content-Type", "text/html");
+
+          return;
+        }
+
+        std::string address_method = "/explorer/address/";
+        if (Common::starts_with(url, address_method)) {
+          std::string address_str = url.substr(address_method.size());
+
+          COMMAND_EXPLORER_GET_ADDRESS::request req;
+          req.address = address_str;
+          COMMAND_EXPLORER_GET_ADDRESS::response rsp;
+
+          bool r = on_get_explorer_address(req, rsp);
+          if (r) {
+            response.setStatus(CryptoNote::HttpResponse::STATUS_200);
+            response.setBody(rsp);
+          }
+          else {
+            response.setStatus(CryptoNote::HttpResponse::STATUS_404);
+            response.setBody("Not found");
+          }
+          response.addHeader("Content-Type", "text/html");
+
+          return;
+        }
+
         // default is explorer home
         uint32_t height = 0;
         if (Common::starts_with(url, page_method)) {
@@ -661,6 +708,9 @@ bool RpcServer::processJsonRpcRequest(const CryptoNote::HttpRequest& request, Cr
       { "submitblock", { makeMemberMethod(&RpcServer::on_submitblock), false } },
       { "resolveopenalias", { makeMemberMethod(&RpcServer::on_resolve_open_alias), true } },
       { "search", { makeMemberMethod(&RpcServer::on_explorer_search), true } },
+      { "resolve_account_number", { makeMemberMethod(&RpcServer::on_resolve_account_number), true } },
+      { "get_account_number", { makeMemberMethod(&RpcServer::on_get_account_number), true } },
+      { "get_all_account_numbers", { makeMemberMethod(&RpcServer::on_get_all_account_numbers), true } },
 
     };
 
@@ -1527,7 +1577,7 @@ bool RpcServer::on_get_explorer(const COMMAND_EXPLORER::request& req, COMMAND_EX
   // Search
   body += R"(
   <form style='padding: 10px;' name='searchform' action='javascript:handleSearch()'>
-    <input type='text' name='search' id='txt_search' size='80' placeholder='Search by block height/hash, transaction hash, payment id...'>
+    <input type='text' name='search' id='txt_search' size='80' placeholder='Search by block height/hash, tx hash, payment id, account number, address...'>
     <input type='submit' value='Search'>
   </form>
   <script>
@@ -1681,13 +1731,35 @@ bool RpcServer::on_get_explorer(const COMMAND_EXPLORER::request& req, COMMAND_EX
 }
 
 bool RpcServer::on_explorer_search(const COMMAND_RPC_EXPLORER_SEARCH::request& req, COMMAND_RPC_EXPLORER_SEARCH::response& res) {
+  // Try account number format (H-I-C)
+  AccountNumber acctNum;
+  if (AccountNumber::fromString(req.query, acctNum)) {
+    AccountPublicAddress address;
+    if (m_core.resolveAccountNumber(acctNum.blockHeight, acctNum.txIndex, address)) {
+      res.result = "/explorer/account/" + req.query;
+      res.status = CORE_RPC_STATUS_OK;
+      return true;
+    }
+  }
+
+  // Try as address
+  {
+    AccountPublicAddress address;
+    uint64_t prefix;
+    if (parseAccountAddressString(prefix, address, req.query)) {
+      res.result = "/explorer/address/" + req.query;
+      res.status = CORE_RPC_STATUS_OK;
+      return true;
+    }
+  }
+
   Crypto::Hash hash;
 
   if (req.query.size() < 64) {
     // assume it's height
     uint32_t height = static_cast<uint32_t>(std::stoul(req.query));
     hash = m_core.getBlockIdByHeight(height);
-  } 
+  }
   else if (!parse_hash256(req.query, hash)) {
     throw JsonRpc::JsonRpcError{
       CORE_RPC_ERROR_CODE_WRONG_PARAM, "Failed to parse query: " + req.query };
@@ -1716,7 +1788,7 @@ bool RpcServer::on_explorer_search(const COMMAND_RPC_EXPLORER_SEARCH::request& r
   }
 
   throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Not found" };
-  
+
   return true;
 }
 
@@ -1913,6 +1985,50 @@ bool RpcServer::on_get_explorer_tx_by_hash(const COMMAND_EXPLORER_GET_TRANSACTIO
       body += "    Payment ID: <span class=\"wrap\">" + Common::podToHex(transactionsDetails.paymentId) + "</span>\n";
       body += "  </li>\n";
     }
+    // Check for account registration in tx extra
+    {
+      TransactionExtraAccountRegistration reg;
+      if (getAccountRegistrationFromExtra(txs.back().extra, reg)) {
+        AccountPublicAddress regAddr;
+        regAddr.spendPublicKey = reg.spendPublicKey;
+        regAddr.viewPublicKey = reg.viewPublicKey;
+        std::string regAddrStr = m_core.currency().accountAddressAsString(regAddr);
+
+        body += "  <li>\n";
+        body += "    Account registration: <a class=\"wrap\" href=\"/explorer/address/" + regAddrStr + "\">"
+             + regAddrStr + "</a>\n";
+        body += "  </li>\n";
+        body += "  <li>\n";
+        body += "    Spend public key: <span class=\"wrap\">" + Common::podToHex(reg.spendPublicKey) + "</span>\n";
+        body += "  </li>\n";
+        body += "  <li>\n";
+        body += "    View public key: <span class=\"wrap\">" + Common::podToHex(reg.viewPublicKey) + "</span>\n";
+        body += "  </li>\n";
+
+        // Show resulting account number if tx is in blockchain
+        if (transactionsDetails.inBlockchain) {
+          // Find tx index within block
+          uint32_t txIdx = 0;
+          uint32_t bh = transactionsDetails.blockHeight;
+          AccountPublicAddress checkAddr;
+          // Walk through possible indices to find this registration
+          for (uint32_t i = 0; i < 1000; ++i) {
+            if (m_core.resolveAccountNumber(bh, i, checkAddr)) {
+              if (checkAddr.spendPublicKey == reg.spendPublicKey &&
+                  checkAddr.viewPublicKey == reg.viewPublicKey) {
+                txIdx = i;
+                AccountNumber an{bh, txIdx};
+                body += "  <li>\n";
+                body += "    Account number: <a href=\"/explorer/account/" + an.toString() + "\">"
+                     + an.toString() + "</a>\n";
+                body += "  </li>\n";
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
     body += "</ul>\n";
 
     body += "<h3>Inputs</h3>\n";
@@ -2056,6 +2172,108 @@ bool RpcServer::on_get_explorer_txs_by_payment_id(const COMMAND_EXPLORER_GET_TRA
 
   res = body;
 
+  return true;
+}
+
+bool RpcServer::on_get_explorer_account_number(const COMMAND_EXPLORER_GET_ACCOUNT_NUMBER::request& req, COMMAND_EXPLORER_GET_ACCOUNT_NUMBER::response& res) {
+  AccountNumber acctNum;
+  if (!AccountNumber::fromString(req.account_number, acctNum)) {
+    return false;
+  }
+
+  AccountPublicAddress address;
+  if (!m_core.resolveAccountNumber(acctNum.blockHeight, acctNum.txIndex, address)) {
+    return false;
+  }
+
+  std::string addressStr = m_core.currency().accountAddressAsString(address);
+
+  std::string body = index_start + (m_core.currency().isTestnet() ? "testnet" : "mainnet") + "\n<p>";
+  body += "<a href=\"/explorer/\">Home</a>";
+  body += "<hr />";
+
+  body += "<h2>Account Number " + acctNum.toString() + "</h2>\n";
+
+  body += "<ul>\n";
+  body += "  <li>\n";
+  body += "    Block height: <a href=\"/explorer/block/" + std::to_string(acctNum.blockHeight) + "\">"
+       + std::to_string(acctNum.blockHeight) + "</a>\n";
+  body += "  </li>\n";
+  body += "  <li>\n";
+  body += "    Transaction index: " + std::to_string(acctNum.txIndex) + "\n";
+  body += "  </li>\n";
+  body += "  <li>\n";
+  body += "    Address: <a class=\"wrap\" href=\"/explorer/address/" + addressStr + "\">"
+       + addressStr + "</a>\n";
+  body += "  </li>\n";
+  body += "  <li>\n";
+  body += "    Spend public key: <span class=\"wrap\">" + Common::podToHex(address.spendPublicKey) + "</span>\n";
+  body += "  </li>\n";
+  body += "  <li>\n";
+  body += "    View public key: <span class=\"wrap\">" + Common::podToHex(address.viewPublicKey) + "</span>\n";
+  body += "  </li>\n";
+  body += "</ul>\n";
+
+  body += index_finish;
+  res = body;
+  return true;
+}
+
+bool RpcServer::on_get_explorer_address(const COMMAND_EXPLORER_GET_ADDRESS::request& req, COMMAND_EXPLORER_GET_ADDRESS::response& res) {
+  AccountPublicAddress address;
+  uint64_t prefix;
+  if (!parseAccountAddressString(prefix, address, req.address)) {
+    return false;
+  }
+
+  bool validSpend = Crypto::check_key(address.spendPublicKey);
+  bool validView = Crypto::check_key(address.viewPublicKey);
+
+  std::string body = index_start + (m_core.currency().isTestnet() ? "testnet" : "mainnet") + "\n<p>";
+  body += "<a href=\"/explorer/\">Home</a>";
+  body += "<hr />";
+
+  body += "<h2>Address</h2>\n";
+  body += "<p class=\"wrap\">" + req.address + "</p>\n";
+
+  body += "<h3>Validation</h3>\n";
+  body += "<ul>\n";
+  body += "  <li>Spend public key: <span class=\"wrap\">" + Common::podToHex(address.spendPublicKey) + "</span>"
+       + (validSpend ? " &#10004;" : " &#10008; <b>INVALID</b>") + "</li>\n";
+  body += "  <li>View public key: <span class=\"wrap\">" + Common::podToHex(address.viewPublicKey) + "</span>"
+       + (validView ? " &#10004;" : " &#10008; <b>INVALID</b>") + "</li>\n";
+  body += "</ul>\n";
+
+  // Look up registered account numbers
+  std::vector<std::pair<uint32_t, uint32_t>> results;
+  m_core.getAllAccountNumbers(address, results);
+
+  if (!results.empty()) {
+    body += "<h3>Registered Account Numbers</h3>\n";
+    body += "<table class=\"counter\" cellpadding=\"10px\">\n";
+    body += "  <thead>\n";
+    body += "  <tr>\n";
+    body += "    <th>Account Number</th><th>Block Height</th><th>TX Index</th>\n";
+    body += "  </tr>\n";
+    body += "  </thead>\n";
+    body += "  <tbody>\n";
+    for (const auto& r : results) {
+      AccountNumber an{r.first, r.second};
+      std::string anStr = an.toString();
+      body += "  <tr>\n";
+      body += "    <td><a href=\"/explorer/account/" + anStr + "\">" + anStr + "</a></td>";
+      body += "    <td><a href=\"/explorer/block/" + std::to_string(r.first) + "\">" + std::to_string(r.first) + "</a></td>";
+      body += "    <td>" + std::to_string(r.second) + "</td>\n";
+      body += "  </tr>\n";
+    }
+    body += "  </tbody>\n";
+    body += "</table>\n";
+  } else {
+    body += "<p>No account numbers registered for this address.</p>\n";
+  }
+
+  body += index_finish;
+  res = body;
   return true;
 }
 
@@ -3253,6 +3471,66 @@ bool RpcServer::on_resolve_open_alias(const COMMAND_RPC_RESOLVE_OPEN_ALIAS::requ
     return true;
   }
 #endif
+
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_resolve_account_number(const COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request& req,
+                                          COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response& res) {
+  AccountNumber acctNum;
+  if (!AccountNumber::fromString(req.account_number, acctNum)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Invalid account number format" };
+  }
+
+  AccountPublicAddress address;
+  if (!m_core.resolveAccountNumber(acctNum.blockHeight, acctNum.txIndex, address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Account number not found" };
+  }
+
+  res.address = m_core.currency().accountAddressAsString(address);
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_get_account_number(const COMMAND_RPC_GET_ACCOUNT_NUMBER::request& req,
+                                      COMMAND_RPC_GET_ACCOUNT_NUMBER::response& res) {
+  AccountPublicAddress address;
+  uint64_t prefix;
+  if (!parseAccountAddressString(prefix, address, req.address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Invalid address" };
+  }
+
+  uint32_t blockHeight, txIndex;
+  if (!m_core.getAccountNumber(address, blockHeight, txIndex)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "No account number registered for this address" };
+  }
+
+  AccountNumber acctNum{blockHeight, txIndex};
+  res.account_number = acctNum.toString();
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_get_all_account_numbers(const COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::request& req,
+                                           COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::response& res) {
+  AccountPublicAddress address;
+  uint64_t prefix;
+  if (!parseAccountAddressString(prefix, address, req.address)) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Invalid address" };
+  }
+
+  std::vector<std::pair<uint32_t, uint32_t>> results;
+  m_core.getAllAccountNumbers(address, results);
+
+  for (const auto& r : results) {
+    AccountNumber acctNum{r.first, r.second};
+    account_number_entry entry;
+    entry.block_height = r.first;
+    entry.tx_index = r.second;
+    entry.account_number = acctNum.toString();
+    res.entries.push_back(entry);
+  }
 
   res.status = CORE_RPC_STATUS_OK;
   return true;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -710,7 +710,6 @@ bool RpcServer::processJsonRpcRequest(const CryptoNote::HttpRequest& request, Cr
       { "search", { makeMemberMethod(&RpcServer::on_explorer_search), true } },
       { "resolve_account_number", { makeMemberMethod(&RpcServer::on_resolve_account_number), true } },
       { "get_account_number", { makeMemberMethod(&RpcServer::on_get_account_number), true } },
-      { "get_all_account_numbers", { makeMemberMethod(&RpcServer::on_get_all_account_numbers), true } },
 
     };
 
@@ -2244,32 +2243,19 @@ bool RpcServer::on_get_explorer_address(const COMMAND_EXPLORER_GET_ADDRESS::requ
        + (validView ? " &#10004;" : " &#10008; <b>INVALID</b>") + "</li>\n";
   body += "</ul>\n";
 
-  // Look up registered account numbers
-  std::vector<std::pair<uint32_t, uint32_t>> results;
-  m_core.getAllAccountNumbers(address, results);
-
-  if (!results.empty()) {
-    body += "<h3>Registered Account Numbers</h3>\n";
-    body += "<table class=\"counter\" cellpadding=\"10px\">\n";
-    body += "  <thead>\n";
-    body += "  <tr>\n";
-    body += "    <th>Account Number</th><th>Block Height</th><th>TX Index</th>\n";
-    body += "  </tr>\n";
-    body += "  </thead>\n";
-    body += "  <tbody>\n";
-    for (const auto& r : results) {
-      AccountNumber an{r.first, r.second};
+  // Look up registered account number
+  {
+    uint32_t blockHeight, txIndex;
+    if (m_core.getAccountNumber(address, blockHeight, txIndex)) {
+      AccountNumber an{blockHeight, txIndex};
       std::string anStr = an.toString();
-      body += "  <tr>\n";
-      body += "    <td><a href=\"/explorer/account/" + anStr + "\">" + anStr + "</a></td>";
-      body += "    <td><a href=\"/explorer/block/" + std::to_string(r.first) + "\">" + std::to_string(r.first) + "</a></td>";
-      body += "    <td>" + std::to_string(r.second) + "</td>\n";
-      body += "  </tr>\n";
+      body += "<h3>Account Number</h3>\n";
+      body += "<p><a href=\"/explorer/account/" + anStr + "\">" + anStr + "</a>"
+              " (block <a href=\"/explorer/block/" + std::to_string(blockHeight) + "\">"
+              + std::to_string(blockHeight) + "</a>)</p>\n";
+    } else {
+      body += "<p>No account number registered for this address.</p>\n";
     }
-    body += "  </tbody>\n";
-    body += "</table>\n";
-  } else {
-    body += "<p>No account numbers registered for this address.</p>\n";
   }
 
   body += index_finish;
@@ -3508,30 +3494,6 @@ bool RpcServer::on_get_account_number(const COMMAND_RPC_GET_ACCOUNT_NUMBER::requ
 
   AccountNumber acctNum{blockHeight, txIndex};
   res.account_number = acctNum.toString();
-  res.status = CORE_RPC_STATUS_OK;
-  return true;
-}
-
-bool RpcServer::on_get_all_account_numbers(const COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::request& req,
-                                           COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::response& res) {
-  AccountPublicAddress address;
-  uint64_t prefix;
-  if (!parseAccountAddressString(prefix, address, req.address)) {
-    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM, "Invalid address" };
-  }
-
-  std::vector<std::pair<uint32_t, uint32_t>> results;
-  m_core.getAllAccountNumbers(address, results);
-
-  for (const auto& r : results) {
-    AccountNumber acctNum{r.first, r.second};
-    account_number_entry entry;
-    entry.block_height = r.first;
-    entry.tx_index = r.second;
-    entry.account_number = acctNum.toString();
-    res.entries.push_back(entry);
-  }
-
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -159,7 +159,6 @@ private:
   bool on_check_payment(const COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::request& req, COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::response& rsp);
   bool on_resolve_account_number(const COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request& req, COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response& res);
   bool on_get_account_number(const COMMAND_RPC_GET_ACCOUNT_NUMBER::request& req, COMMAND_RPC_GET_ACCOUNT_NUMBER::response& res);
-  bool on_get_all_account_numbers(const COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::request& req, COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::response& res);
 
   void fill_block_header_response(const Block& blk, bool orphan_status, uint32_t height, const Crypto::Hash& hash, block_header_response& responce);
   void listen(const std::string address, const uint16_t port);

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -102,6 +102,8 @@ private:
   bool on_get_explorer_block_by_hash(const COMMAND_EXPLORER_GET_BLOCK_DETAILS_BY_HASH::request& req, COMMAND_EXPLORER_GET_BLOCK_DETAILS_BY_HASH::response& res);
   bool on_get_explorer_tx_by_hash(const COMMAND_EXPLORER_GET_TRANSACTION_DETAILS_BY_HASH::request& req, COMMAND_EXPLORER_GET_TRANSACTION_DETAILS_BY_HASH::response& res);
   bool on_get_explorer_txs_by_payment_id(const COMMAND_EXPLORER_GET_TRANSACTIONS_BY_PAYMENT_ID::request& req, COMMAND_EXPLORER_GET_TRANSACTIONS_BY_PAYMENT_ID::response& res);
+  bool on_get_explorer_account_number(const COMMAND_EXPLORER_GET_ACCOUNT_NUMBER::request& req, COMMAND_EXPLORER_GET_ACCOUNT_NUMBER::response& res);
+  bool on_get_explorer_address(const COMMAND_EXPLORER_GET_ADDRESS::request& req, COMMAND_EXPLORER_GET_ADDRESS::response& res);
   bool on_explorer_search(const COMMAND_RPC_EXPLORER_SEARCH::request& req, COMMAND_RPC_EXPLORER_SEARCH::response& res);
 
   // json handlers
@@ -155,6 +157,9 @@ private:
   bool on_get_stats_by_heights_range(const COMMAND_RPC_GET_STATS_BY_HEIGHTS_RANGE::request& req, COMMAND_RPC_GET_STATS_BY_HEIGHTS_RANGE::response& res);
   bool on_resolve_open_alias(const COMMAND_RPC_RESOLVE_OPEN_ALIAS::request& req, COMMAND_RPC_RESOLVE_OPEN_ALIAS::response& res);
   bool on_check_payment(const COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::request& req, COMMAND_RPC_CHECK_PAYMENT_BY_PAYMENT_ID::response& rsp);
+  bool on_resolve_account_number(const COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request& req, COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response& res);
+  bool on_get_account_number(const COMMAND_RPC_GET_ACCOUNT_NUMBER::request& req, COMMAND_RPC_GET_ACCOUNT_NUMBER::response& res);
+  bool on_get_all_account_numbers(const COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::request& req, COMMAND_RPC_GET_ALL_ACCOUNT_NUMBERS::response& res);
 
   void fill_block_header_response(const Block& blk, bool orphan_status, uint32_t height, const Crypto::Hash& hash, block_header_response& responce);
   void listen(const std::string address, const uint16_t port);

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -70,7 +70,9 @@
 #include "Common/Util.h"
 #include "Common/ColouredMsg.h"
 #include "CryptoNoteCore/Account.h"
+#include "CryptoNoteCore/AccountNumber.h"
 #include "CryptoNoteCore/CryptoNoteFormatUtils.h"
+#include "CryptoNoteCore/TransactionExtra.h"
 #include "CryptoNoteCore/CryptoNoteTools.h"
 #include "CryptoNoteProtocol/CryptoNoteProtocolHandler.h"
 #include "NodeRpcProxy/NodeRpcProxy.h"
@@ -294,18 +296,41 @@ struct TransferCommand {
           std::string aliasUrl;
 #endif
           if (!m_currency.parseAccountAddressString(arg, deAddr)) {
-            Crypto::Hash paymentId;
-            if (CryptoNote::parsePaymentId(arg, paymentId)) {
-              logger(ERROR, BRIGHT_RED) << "Invalid payment ID usage. Please, use -p <payment_id>. See help for details.";
-            } else {
-#ifndef __ANDROID__
-              // if string doesn't contain a dot, we won't consider it a url for now.
-              if (strchr(arg.c_str(), '.') == NULL) {
-                logger(ERROR, BRIGHT_RED) << "Wrong address or alias: " << arg;
+            // Try to resolve as account number (e.g. 1821033-7-K)
+            CryptoNote::AccountNumber acctNum;
+            if (CryptoNote::AccountNumber::fromString(arg, acctNum)) {
+              std::string resolvedAddress;
+              std::promise<std::error_code> promise;
+              auto future = promise.get_future();
+              const_cast<CryptoNote::NodeRpcProxy&>(m_node).resolveAccountNumber(
+                  arg, resolvedAddress,
+                  [&promise](std::error_code ec) { promise.set_value(ec); });
+              auto ec = future.get();
+              if (!ec && !resolvedAddress.empty()) {
+                logger(INFO) << "Account number " << arg << " resolved to: " << resolvedAddress;
+                arg = resolvedAddress;
+                if (!m_currency.parseAccountAddressString(arg, deAddr)) {
+                  logger(ERROR, BRIGHT_RED) << "Resolved address is invalid: " << arg;
+                  return false;
+                }
+              } else {
+                logger(ERROR, BRIGHT_RED) << "Failed to resolve account number: " << arg;
                 return false;
               }
-              aliasUrl = arg;
+            } else {
+              Crypto::Hash paymentId;
+              if (CryptoNote::parsePaymentId(arg, paymentId)) {
+                logger(ERROR, BRIGHT_RED) << "Invalid payment ID usage. Please, use -p <payment_id>. See help for details.";
+              } else {
+#ifndef __ANDROID__
+                // if string doesn't contain a dot, we won't consider it a url for now.
+                if (strchr(arg.c_str(), '.') == NULL) {
+                  logger(ERROR, BRIGHT_RED) << "Wrong address or alias: " << arg;
+                  return false;
+                }
+                aliasUrl = arg;
 #endif
+              }
             }
           }
 
@@ -669,6 +694,7 @@ simple_wallet::simple_wallet(System::Dispatcher& dispatcher, const CryptoNote::C
     "If 'all' is specified, you prove the entire accounts' balance.\n");
   m_consoleHandler.setHandler("sign_message", std::bind(&simple_wallet::sign_message, this, std::placeholders::_1), "Sign the message");
   m_consoleHandler.setHandler("verify_message", std::bind(&simple_wallet::verify_message, this, std::placeholders::_1), "Verify a signature of the message");
+  m_consoleHandler.setHandler("register_account", std::bind(&simple_wallet::register_account, this, std::placeholders::_1), "Register an account number for easy payments");
   m_consoleHandler.setHandler("help", std::bind(&simple_wallet::help, this, std::placeholders::_1), "Show this help");
   m_consoleHandler.setHandler("exit", std::bind(&simple_wallet::exit, this, std::placeholders::_1), "Close wallet");
 }
@@ -2346,6 +2372,18 @@ void simple_wallet::stop() {
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::print_address(const std::vector<std::string> &args/* = std::vector<std::string>()*/) {
   success_msg_writer() << m_wallet->getAddress();
+
+  /* Check for registered account number */
+  std::string accountNumber;
+  std::promise<std::error_code> promise;
+  auto future = promise.get_future();
+  m_node->getAccountNumber(m_wallet->getAddress(), accountNumber,
+      [&promise](std::error_code ec) { promise.set_value(ec); });
+  auto ec = future.get();
+  if (!ec && !accountNumber.empty()) {
+    success_msg_writer() << "Account number: " << accountNumber;
+  }
+
   return true;
 }
 //----------------------------------------------------------------------------------------------------
@@ -2401,6 +2439,86 @@ bool simple_wallet::verify_message(const std::vector<std::string> &args) {
   } else {
     success_msg_writer(true) << "Valid signature from " << address_string;
   }
+  return true;
+}
+//----------------------------------------------------------------------------------------------------
+bool simple_wallet::register_account(const std::vector<std::string> &args) {
+  if (m_trackingWallet) {
+    fail_msg_writer() << "This is a tracking wallet. Cannot register account number.";
+    return true;
+  }
+
+  // Check if already registered
+  std::string existingNumber;
+  {
+    std::promise<std::error_code> promise;
+    auto future = promise.get_future();
+    m_node->getAccountNumber(m_wallet->getAddress(), existingNumber,
+        [&promise](std::error_code ec) { promise.set_value(ec); });
+    auto ec = future.get();
+    if (!ec && !existingNumber.empty()) {
+      logger(WARNING, YELLOW) << "This address already has account number: " << existingNumber;
+      logger(WARNING, YELLOW) << "Re-registering will create a new account number.";
+      std::cout << "Proceed with re-registration? (y/N): ";
+      std::string confirm;
+      std::getline(std::cin, confirm);
+      if (confirm.empty() || (confirm[0] != 'y' && confirm[0] != 'Y')) {
+        logger(INFO) << "Cancelled.";
+        return true;
+      }
+    } else {
+      std::cout << "Register an account number for easy payments? (small fee applies) (Y/n): ";
+      std::string confirm;
+      std::getline(std::cin, confirm);
+      if (!confirm.empty() && confirm[0] != 'y' && confirm[0] != 'Y') {
+        logger(INFO) << "Cancelled.";
+        return true;
+      }
+    }
+  }
+
+  // Build registration tx extra
+  CryptoNote::AccountKeys keys;
+  m_wallet->getAccountKeys(keys);
+
+  std::vector<uint8_t> extra;
+  CryptoNote::addAccountRegistrationToExtra(extra, keys.address.spendPublicKey, keys.address.viewPublicKey);
+
+  std::string extraString;
+  std::copy(extra.begin(), extra.end(), std::back_inserter(extraString));
+
+  // Send a self-transfer with the registration extra
+  try {
+    CryptoNote::WalletLegacyTransfer transfer;
+    transfer.address = m_wallet->getAddress();
+    transfer.amount = CryptoNote::parameters::DEFAULT_DUST_THRESHOLD;
+
+    CryptoNote::WalletHelper::SendCompleteResultObserver sent;
+    WalletHelper::IWalletRemoveObserverGuard removeGuard(*m_wallet, sent);
+
+    CryptoNote::TransactionId tx = m_wallet->sendTransaction(transfer, m_node->getMinimalFee(), extraString, 0, 0);
+    if (tx == WALLET_LEGACY_INVALID_TRANSACTION_ID) {
+      fail_msg_writer() << "Can't send registration transaction";
+      return true;
+    }
+
+    std::error_code sendError = sent.wait(tx);
+    removeGuard.removeObserver();
+
+    if (sendError) {
+      fail_msg_writer() << sendError.message();
+      return true;
+    }
+
+    CryptoNote::WalletLegacyTransaction txInfo;
+    m_wallet->getTransaction(tx, txInfo);
+    success_msg_writer(true) << "Account registration transaction sent!";
+    success_msg_writer(true) << "Transaction hash: " << Common::podToHex(txInfo.hash);
+    logger(INFO) << "Your account number will be available once the transaction is confirmed.";
+  } catch (const std::exception& e) {
+    fail_msg_writer() << "Failed to send registration transaction: " << e.what();
+  }
+
   return true;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -2457,23 +2457,16 @@ bool simple_wallet::register_account(const std::vector<std::string> &args) {
         [&promise](std::error_code ec) { promise.set_value(ec); });
     auto ec = future.get();
     if (!ec && !existingNumber.empty()) {
-      logger(WARNING, YELLOW) << "This address already has account number: " << existingNumber;
-      logger(WARNING, YELLOW) << "Re-registering will create a new account number.";
-      std::cout << "Proceed with re-registration? (y/N): ";
-      std::string confirm;
-      std::getline(std::cin, confirm);
-      if (confirm.empty() || (confirm[0] != 'y' && confirm[0] != 'Y')) {
-        logger(INFO) << "Cancelled.";
-        return true;
-      }
-    } else {
-      std::cout << "Register an account number for easy payments? (small fee applies) (Y/n): ";
-      std::string confirm;
-      std::getline(std::cin, confirm);
-      if (!confirm.empty() && confirm[0] != 'y' && confirm[0] != 'Y') {
-        logger(INFO) << "Cancelled.";
-        return true;
-      }
+      fail_msg_writer() << "This address already has account number: " << existingNumber;
+      return true;
+    }
+
+    std::cout << "Register an account number for easy payments? (small fee applies) (Y/n): ";
+    std::string confirm;
+    std::getline(std::cin, confirm);
+    if (!confirm.empty() && confirm[0] != 'y' && confirm[0] != 'Y') {
+      logger(INFO) << "Cancelled.";
+      return true;
     }
   }
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -130,6 +130,7 @@ namespace CryptoNote
     bool get_reserve_proof(const std::vector<std::string> &args);
     bool sign_message(const std::vector<std::string> &args);
     bool verify_message(const std::vector<std::string> &args);
+    bool register_account(const std::vector<std::string> &args);
 
     std::string get_formatted_wallet_keys();
 

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -42,6 +42,8 @@ public:
   WalletGreen(System::Dispatcher& dispatcher, const Currency& currency, INode& node, Logging::ILogger& logger, uint32_t transactionSoftLockTime = CryptoNote::parameters::CRYPTONOTE_TX_SPENDABLE_AGE);
   virtual ~WalletGreen();
 
+  INode& getNode() { return m_node; }
+
   virtual void initialize(const std::string& path, const std::string& password) override;
   virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey) override;
   virtual void initializeWithViewKey(const std::string& path, const std::string& password, const Crypto::SecretKey& viewSecretKey, const uint64_t& creationTimestamp) override;

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -938,6 +938,20 @@ bool wallet_rpc_server::on_get_account_number(const wallet_rpc::COMMAND_RPC_GET_
 bool wallet_rpc_server::on_register_account(const wallet_rpc::COMMAND_RPC_REGISTER_ACCOUNT::request& req,
   wallet_rpc::COMMAND_RPC_REGISTER_ACCOUNT::response& res)
 {
+  // Check if already registered
+  {
+    std::string existingNumber;
+    std::promise<std::error_code> promise;
+    auto future = promise.get_future();
+    m_node.getAccountNumber(m_wallet.getAddress(), existingNumber,
+        [&promise](std::error_code ec) { promise.set_value(ec); });
+    auto ec = future.get();
+    if (!ec && !existingNumber.empty()) {
+      throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR,
+        "This address already has account number: " + existingNumber);
+    }
+  }
+
   // Build registration tx extra
   CryptoNote::AccountKeys keys;
   m_wallet.getAccountKeys(keys);

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -19,6 +19,7 @@
 // along with Karbo.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <list>
+#include <limits>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
 
@@ -885,6 +886,11 @@ bool wallet_rpc_server::on_resolve_account_number(const wallet_rpc::COMMAND_RPC_
 {
   CryptoNote::AccountNumber acctNum;
   if (!CryptoNote::AccountNumber::fromString(req.account_number, acctNum)) {
+    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_ADDRESS, "Invalid account number format");
+  }
+  if (acctNum.txIndex == 0 ||
+      acctNum.txIndex > std::numeric_limits<uint16_t>::max() ||
+      acctNum.blockHeight > m_node.getLastLocalBlockHeight()) {
     throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_ADDRESS, "Invalid account number format");
   }
 

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -37,6 +37,8 @@
 #include "Common/Base58.h"
 #include "Common/Util.h"
 #include "WalletRpcServer.h"
+#include "CryptoNoteCore/AccountNumber.h"
+#include "CryptoNoteCore/TransactionExtra.h"
 
 #undef ERROR
 
@@ -268,6 +270,9 @@ void wallet_rpc_server::processRequest(const CryptoNote::HttpRequest& request, C
             { "sign_message"      , makeMemberMethod(&wallet_rpc_server::on_sign_message)      },
             { "verify_message"    , makeMemberMethod(&wallet_rpc_server::on_verify_message)    },
             { "change_password"   , makeMemberMethod(&wallet_rpc_server::on_change_password)   },
+            { "resolve_account_number", makeMemberMethod(&wallet_rpc_server::on_resolve_account_number) },
+            { "get_account_number",     makeMemberMethod(&wallet_rpc_server::on_get_account_number)     },
+            { "register_account",       makeMemberMethod(&wallet_rpc_server::on_register_account)       },
     };
 
     auto it = s_methods.find(jsonRequest.getMethod());
@@ -345,6 +350,27 @@ bool wallet_rpc_server::on_transfer(const wallet_rpc::COMMAND_RPC_TRANSFER::requ
     CryptoNote::WalletLegacyTransfer transfer;
     transfer.address = it->address;
     transfer.amount  = it->amount;
+
+    // Try to resolve account number if address parsing fails
+    CryptoNote::AccountPublicAddress ignore;
+    if (!m_currency.parseAccountAddressString(transfer.address, ignore)) {
+      CryptoNote::AccountNumber acctNum;
+      if (CryptoNote::AccountNumber::fromString(transfer.address, acctNum)) {
+        std::string resolvedAddress;
+        std::promise<std::error_code> promise;
+        auto future = promise.get_future();
+        m_node.resolveAccountNumber(transfer.address, resolvedAddress,
+            [&promise](std::error_code ec) { promise.set_value(ec); });
+        auto ec = future.get();
+        if (!ec && !resolvedAddress.empty()) {
+          transfer.address = resolvedAddress;
+        } else {
+          throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_ADDRESS,
+            "Failed to resolve account number: " + it->address);
+        }
+      }
+    }
+
     transfers.push_back(transfer);
   }
 
@@ -649,10 +675,22 @@ bool wallet_rpc_server::on_get_height(const wallet_rpc::COMMAND_RPC_GET_HEIGHT::
   return true;
 }
 
-bool wallet_rpc_server::on_get_address(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, 
+bool wallet_rpc_server::on_get_address(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req,
   wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res)
 {
   res.address = m_wallet.getAddress();
+
+  // Look up account number
+  std::string accountNumber;
+  std::promise<std::error_code> promise;
+  auto future = promise.get_future();
+  m_node.getAccountNumber(res.address, accountNumber,
+      [&promise](std::error_code ec) { promise.set_value(ec); });
+  auto ec = future.get();
+  if (!ec && !accountNumber.empty()) {
+    res.account_number = accountNumber;
+  }
+
   return true;
 }
 
@@ -850,6 +888,95 @@ bool wallet_rpc_server::on_change_password(const wallet_rpc::COMMAND_RPC_CHANGE_
     res.password_changed = false;
   }
   logger(Logging::INFO) << "Password changed via RPC.";
+  return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+bool wallet_rpc_server::on_resolve_account_number(const wallet_rpc::COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request& req,
+  wallet_rpc::COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response& res)
+{
+  CryptoNote::AccountNumber acctNum;
+  if (!CryptoNote::AccountNumber::fromString(req.account_number, acctNum)) {
+    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_ADDRESS, "Invalid account number format");
+  }
+
+  std::string resolvedAddress;
+  std::promise<std::error_code> promise;
+  auto future = promise.get_future();
+  m_node.resolveAccountNumber(req.account_number, resolvedAddress,
+      [&promise](std::error_code ec) { promise.set_value(ec); });
+  auto ec = future.get();
+  if (ec || resolvedAddress.empty()) {
+    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_WRONG_ADDRESS, "Account number not found");
+  }
+
+  res.address = resolvedAddress;
+  res.status = WALLET_RPC_STATUS_OK;
+  return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+bool wallet_rpc_server::on_get_account_number(const wallet_rpc::COMMAND_RPC_GET_ACCOUNT_NUMBER::request& req,
+  wallet_rpc::COMMAND_RPC_GET_ACCOUNT_NUMBER::response& res)
+{
+  std::string accountNumber;
+  std::promise<std::error_code> promise;
+  auto future = promise.get_future();
+  m_node.getAccountNumber(m_wallet.getAddress(), accountNumber,
+      [&promise](std::error_code ec) { promise.set_value(ec); });
+  auto ec = future.get();
+  if (ec || accountNumber.empty()) {
+    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR, "No account number registered for this wallet");
+  }
+
+  res.account_number = accountNumber;
+  res.status = WALLET_RPC_STATUS_OK;
+  return true;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------
+bool wallet_rpc_server::on_register_account(const wallet_rpc::COMMAND_RPC_REGISTER_ACCOUNT::request& req,
+  wallet_rpc::COMMAND_RPC_REGISTER_ACCOUNT::response& res)
+{
+  // Build registration tx extra
+  CryptoNote::AccountKeys keys;
+  m_wallet.getAccountKeys(keys);
+
+  std::vector<uint8_t> extra;
+  CryptoNote::addAccountRegistrationToExtra(extra, keys.address.spendPublicKey, keys.address.viewPublicKey);
+
+  std::string extraString;
+  std::copy(extra.begin(), extra.end(), std::back_inserter(extraString));
+
+  try
+  {
+    CryptoNote::WalletHelper::SendCompleteResultObserver sent;
+    WalletHelper::IWalletRemoveObserverGuard removeGuard(m_wallet, sent);
+
+    CryptoNote::WalletLegacyTransfer transfer;
+    transfer.address = m_wallet.getAddress();
+    transfer.amount = CryptoNote::parameters::DEFAULT_DUST_THRESHOLD;
+
+    CryptoNote::TransactionId tx = m_wallet.sendTransaction(transfer, m_node.getMinimalFee(), extraString, 0, 0);
+    if (tx == WALLET_LEGACY_INVALID_TRANSACTION_ID)
+      throw std::runtime_error("Couldn't send registration transaction");
+
+    std::error_code sendError = sent.wait(tx);
+    removeGuard.removeObserver();
+
+    if (sendError)
+      throw std::system_error(sendError);
+
+    CryptoNote::WalletLegacyTransaction txInfo;
+    m_wallet.getTransaction(tx, txInfo);
+    res.tx_hash = Common::podToHex(txInfo.hash);
+    res.tx_key = Common::podToHex(txInfo.secretKey);
+  }
+  catch (const std::exception& e)
+  {
+    throw JsonRpc::JsonRpcError(WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR, e.what());
+  }
+
   return true;
 }
 

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -679,18 +679,6 @@ bool wallet_rpc_server::on_get_address(const wallet_rpc::COMMAND_RPC_GET_ADDRESS
   wallet_rpc::COMMAND_RPC_GET_ADDRESS::response& res)
 {
   res.address = m_wallet.getAddress();
-
-  // Look up account number
-  std::string accountNumber;
-  std::promise<std::error_code> promise;
-  auto future = promise.get_future();
-  m_node.getAccountNumber(res.address, accountNumber,
-      [&promise](std::error_code ec) { promise.set_value(ec); });
-  auto ec = future.get();
-  if (!ec && !accountNumber.empty()) {
-    res.account_number = accountNumber;
-  }
-
   return true;
 }
 

--- a/src/Wallet/WalletRpcServer.h
+++ b/src/Wallet/WalletRpcServer.h
@@ -90,6 +90,9 @@ private:
   bool on_gen_paymentid(const wallet_rpc::COMMAND_RPC_GET_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_GEN_PAYMENT_ID::response& res);
   bool on_validate_address(const wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::request& req, wallet_rpc::COMMAND_RPC_VALIDATE_ADDRESS::response& res);
   bool on_reset(const wallet_rpc::COMMAND_RPC_RESET::request& req, wallet_rpc::COMMAND_RPC_RESET::response& res);
+  bool on_resolve_account_number(const wallet_rpc::COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::request& req, wallet_rpc::COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER::response& res);
+  bool on_get_account_number(const wallet_rpc::COMMAND_RPC_GET_ACCOUNT_NUMBER::request& req, wallet_rpc::COMMAND_RPC_GET_ACCOUNT_NUMBER::response& res);
+  bool on_register_account(const wallet_rpc::COMMAND_RPC_REGISTER_ACCOUNT::request& req, wallet_rpc::COMMAND_RPC_REGISTER_ACCOUNT::response& res);
 
   bool handle_command_line(const boost::program_options::variables_map& vm);
   bool authenticate(const CryptoNote::HttpRequest& request) const;

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -301,10 +301,12 @@ using CryptoNote::ISerializer;
     struct response
     {
       std::string address;
+      std::string account_number;
 
       void serialize(ISerializer& s)
       {
         KV_MEMBER(address)
+        KV_MEMBER(account_number)
       }
     };
   };
@@ -510,6 +512,65 @@ using CryptoNote::ISerializer;
         KV_MEMBER(spend_public_key)
         KV_MEMBER(view_public_key)
         KV_MEMBER(status)
+      }
+    };
+  };
+
+  /* Command: resolve_account_number */
+  struct COMMAND_RPC_RESOLVE_ACCOUNT_NUMBER
+  {
+    struct request
+    {
+      std::string account_number;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(account_number)
+      }
+    };
+    struct response
+    {
+      std::string address;
+      std::string status;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(address)
+        KV_MEMBER(status)
+      }
+    };
+  };
+
+  /* Command: get_account_number */
+  struct COMMAND_RPC_GET_ACCOUNT_NUMBER
+  {
+    typedef CryptoNote::EMPTY_STRUCT request;
+    struct response
+    {
+      std::string account_number;
+      std::string status;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(account_number)
+        KV_MEMBER(status)
+      }
+    };
+  };
+
+  /* Command: register_account */
+  struct COMMAND_RPC_REGISTER_ACCOUNT
+  {
+    typedef CryptoNote::EMPTY_STRUCT request;
+    struct response
+    {
+      std::string tx_hash;
+      std::string tx_key;
+
+      void serialize(ISerializer& s)
+      {
+        KV_MEMBER(tx_hash)
+        KV_MEMBER(tx_key)
       }
     };
   };

--- a/src/Wallet/WalletRpcServerCommandsDefinitions.h
+++ b/src/Wallet/WalletRpcServerCommandsDefinitions.h
@@ -301,12 +301,10 @@ using CryptoNote::ISerializer;
     struct response
     {
       std::string address;
-      std::string account_number;
 
       void serialize(ISerializer& s)
       {
         KV_MEMBER(address)
-        KV_MEMBER(account_number)
       }
     };
   };


### PR DESCRIPTION
Add human-readable account numbers as alternative to CryptoNote addresses Introduce a system where users can register a short account number (e.g. `1264265-1-W`) by broadcasting a special transaction containing their public keys. The account number is derived from the block height and transaction index where the registration is mined, with a Luhn mod 36 check character for error detection.

This evolved from idea we've been working for a long time with Dado 

- Define TX_EXTRA_TAG_ACCOUNT_REGISTRATION (0x04) with 65-byte payload (tag + spend + view pubkeys)
- Add AccountNumber class with Luhn mod 36 check character generation/validation
- Add LMDB table (acct_reg) using big-endian keys with push/pop hooks in Blockchain for maintaining the index
- Add semantic validation: valid Ed25519 keys, no identity point, no payment ID conflict
- Only valid well-formed registations will be indexed in db and resolved
- No hardfork or softfork: does not influence consensus, transactions with malformed registration will be rejected from mempool but blocks are accepted to avoid unncecessary hardforks
- First registration is canonic, nodes will not resolve consecutive registrations
- Add JSON-RPC endpoints: `resolveaccountnumber`, `getaccountnumber`
- Extend INode with default resolveAccountNumber/getAccountNumber methods
- Implement NodeRpcProxy methods for wallet-daemon communication
- Add register_account command to GreenWallet with self-transfer registration tx
- Add account number resolution in both SimpleWallet and GreenWallet transfer flows
- Display registered account number alongside address in both wallets
- Add account number support to SimpleWallet and WalletRpcServer
- Backfill account registration index on startup for pre-index blocks: On first run, scan backwards from chain tip down to block 1,264,265 (first known registration at tx index 1) for well-formed registrations and insert missing entries into the LMDB index. Use presence of the first registration entry (1264265, 1) as the completion marker.

## Node RPC JSON API examples:

Request:

```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "getaccountnumber",
  "params": {
   "address":"King4d4MuueFVNTnTpxjVLEDTq3jh82ufdFCbTUMLg9g1w8KMUJSAKZUFqzEfBNrJw4LCPCZde1ibda1Sun7cyG1QqgHsby"
  }
}
```

Response:
```
{
    "id": "test",
    "jsonrpc": "2.0",
    "result": {
        "account_number": "1256970-1-P",
        "status": "OK"
    }
}
```


Request:
```
{
  "jsonrpc": "2.0",
  "id": "test",
  "method": "resolveaccountnumber",
  "params": {
   "account_number":"1256970-1-P"
  }
}
```

Response:
```
{
    "id": "test",
    "jsonrpc": "2.0",
    "result": {
        "address": "King4d4MuueFVNTnTpxjVLEDTq3jh82ufdFCbTUMLg9g1w8KMUJSAKZUFqzEfBNrJw4LCPCZde1ibda1Sun7cyG1QqgHsby",
        "status": "OK"
    }
}
```



